### PR TITLE
fix typo in DropdownContext doc

### DIFF
--- a/src/components/Dropdown/DropdownContext.ts
+++ b/src/components/Dropdown/DropdownContext.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react';
 
 /**
- * The Context responsibile for the Dropdown state.
+ * The Context responsible for the Dropdown state.
  */
 export type DropdownContextType = {
   isActive: boolean,


### PR DESCRIPTION
I didn't rebuild the documentation since that would probably clobber @cea2aj 's documentation review branch,
as code was committed in between when https://github.com/yext/answers-react-components/pull/25 last branched off of main and when it was merged in

J=NONE
TEST=NONE