### PR TITLE
rename import verticalResults from core to VerticalResultsModel

### DIFF
--- a/src/components/AlternativeVerticals.tsx
+++ b/src/components/AlternativeVerticals.tsx
@@ -1,6 +1,6 @@
 import { processTranslation } from './utils/processTranslation';
 import Star from '../icons/StarIcon';
-import { useAnswersState, VerticalResults as VerticalResultsModel } from '@yext/answers-headless-react';
+import { useAnswersState, VerticalResults as VerticalResultsData } from '@yext/answers-headless-react';
 import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCssClasses';
 import classNames from 'classnames';
 
@@ -109,10 +109,10 @@ export default function AlternativeVerticals({
 
   function buildVerticalSuggestions(
     verticalsConfig: VerticalConfig[],
-    alternativeVerticals: VerticalResultsModel[]): VerticalSuggestion[] {
+    alternativeVerticals: VerticalResultsData[]): VerticalSuggestion[] {
 
     return alternativeVerticals
-      .map((alternativeResults: VerticalResultsModel) => {
+      .map((alternativeResults: VerticalResultsData) => {
         const matchingVerticalConfig = verticalsConfig.find(config => {
           return config.verticalKey === alternativeResults.verticalKey;
         });

--- a/src/components/DirectAnswer.tsx
+++ b/src/components/DirectAnswer.tsx
@@ -1,4 +1,4 @@
-import { useAnswersState, DirectAnswerType, DirectAnswer as DirectAnswerModel } from '@yext/answers-headless-react';
+import { useAnswersState, DirectAnswerType, DirectAnswer as DirectAnswerData } from '@yext/answers-headless-react';
 import renderHighlightedValue from './utils/renderHighlightedValue';
 import classNames from 'classnames';
 import { ReactNode, useState, useLayoutEffect } from 'react';
@@ -70,7 +70,7 @@ export default function DirectAnswer(props: DirectAnswerProps): JSX.Element | nu
     : directAnswerResult.value;
   const link = directAnswerResult.relatedResult.link;
 
-  function getLinkText(directAnswerResult: DirectAnswerModel) {
+  function getLinkText(directAnswerResult: DirectAnswerData) {
     const isSnippet = directAnswerResult.type === DirectAnswerType.FeaturedSnippet;
     const name = directAnswerResult.relatedResult.name;
     const onClick = () => {

--- a/src/components/EntityPreviews.tsx
+++ b/src/components/EntityPreviews.tsx
@@ -1,4 +1,4 @@
-import { Result, VerticalResults as VerticalResultsModel, UniversalLimit } from '@yext/answers-headless-react';
+import { Result, VerticalResults as VerticalResultsData, UniversalLimit } from '@yext/answers-headless-react';
 import { cloneElement, isValidElement, ReactNode } from 'react';
 import DropdownItem from './Dropdown/DropdownItem';
 import recursivelyMapChildren from './utils/recursivelyMapChildren';
@@ -28,7 +28,7 @@ export default function EntityPreviews(_: EntityPreviewsProps): JSX.Element | nu
  */
 export function transformEntityPreviews(
   entityPreviews: JSX.Element,
-  verticalResultsArray: VerticalResultsModel[]
+  verticalResultsArray: VerticalResultsData[]
 ): ReactNode {
   const verticalKeyToResults = getVerticalKeyToResults(verticalResultsArray);
   let index = 0;
@@ -54,7 +54,7 @@ export function transformEntityPreviews(
 /**
  * @returns a mapping of vertical key to VerticalResults
  */
-function getVerticalKeyToResults(verticalResultsArray: VerticalResultsModel[]): Record<string, Result[]> {
+function getVerticalKeyToResults(verticalResultsArray: VerticalResultsData[]): Record<string, Result[]> {
   return verticalResultsArray.reduce<Record<string, Result[]>>((prev, current) => {
     prev[current.verticalKey] = current.results;
     return prev;

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -5,7 +5,7 @@ import {
   useAnswersActions,
   useAnswersState,
   useAnswersUtilities,
-  VerticalResults as VerticalResultsModel
+  VerticalResults as VerticalResultsData
 } from '@yext/answers-headless-react';
 import classNames from 'classnames';
 import { Fragment, PropsWithChildren, useEffect } from 'react';
@@ -89,7 +89,7 @@ export interface SearchBarCssClasses extends AutocompleteResultCssClasses {
 
 export type RenderEntityPreviews = (
   autocompleteLoading: boolean,
-  verticalResultsArray: VerticalResultsModel[],
+  verticalResultsArray: VerticalResultsData[],
   onSubmit: (value: string, _index: number, itemData?: FocusedItemData) => void
 ) => JSX.Element;
 

--- a/src/components/UniversalResults.tsx
+++ b/src/components/UniversalResults.tsx
@@ -1,4 +1,4 @@
-import { useAnswersState, VerticalResults as VerticalResultsModel } from '@yext/answers-headless-react';
+import { useAnswersState, VerticalResults as VerticalResultsData } from '@yext/answers-headless-react';
 import StandardSection from '../sections/StandardSection';
 import SectionHeader from '../sections/SectionHeader';
 import { SectionComponent } from '../models/sectionComponent';
@@ -80,7 +80,7 @@ export default function UniversalResults({
 }
 
 interface VerticalSectionsProps extends UniversalResultsProps {
-  resultsFromAllVerticals: VerticalResultsModel[]
+  resultsFromAllVerticals: VerticalResultsData[]
 }
 
 /**

--- a/src/hooks/useDirectAnswerAnalytics.ts
+++ b/src/hooks/useDirectAnswerAnalytics.ts
@@ -1,18 +1,18 @@
-import { useAnswersState, DirectAnswerType, DirectAnswer as DirectAnswerModel, FieldValueDirectAnswer } from '@yext/answers-headless-react';
+import { useAnswersState, DirectAnswerType, DirectAnswer as DirectAnswerData, FieldValueDirectAnswer } from '@yext/answers-headless-react';
 import { useAnalytics } from './useAnalytics';
 
 export type FeedbackType = 'THUMBS_UP' | 'THUMBS_DOWN';
 type DirectAnswerAnalyticsType = FeedbackType | 'CTA_CLICK';
 
 export function useDirectAnswersAnalytics(): (
-  directAnswerResult: DirectAnswerModel,
+  directAnswerResult: DirectAnswerData,
   analyticsEventType: DirectAnswerAnalyticsType
 ) => void {
   const analytics = useAnalytics();
   const verticalKey = useAnswersState(state => state.vertical.verticalKey);
   const queryId = useAnswersState(state => state.query.queryId);
 
-  const reportCtaEvent = (directAnswerResult: DirectAnswerModel) => {
+  const reportCtaEvent = (directAnswerResult: DirectAnswerData) => {
     const link = directAnswerResult.relatedResult.link;
     const entityId = directAnswerResult.relatedResult.id;
     const fieldName = directAnswerResult.type === DirectAnswerType.FeaturedSnippet
@@ -37,7 +37,7 @@ export function useDirectAnswersAnalytics(): (
       fieldName
     });
   };
-  const reportFeedbackEvent = (directAnswerResult: DirectAnswerModel, feedbackType: FeedbackType) => {
+  const reportFeedbackEvent = (directAnswerResult: DirectAnswerData, feedbackType: FeedbackType) => {
     if (!queryId) {
       console.error('Unable to report a direct answer feedback event. Missing field: queryId.');
       return;
@@ -53,7 +53,7 @@ export function useDirectAnswersAnalytics(): (
     });
   };
   const reportAnalyticsEvent = (
-    directAnswerResult: DirectAnswerModel,
+    directAnswerResult: DirectAnswerData,
     analyticsEventType: DirectAnswerAnalyticsType
   ) => {
     if (!analytics) {

--- a/src/hooks/useEntityPreviews.tsx
+++ b/src/hooks/useEntityPreviews.tsx
@@ -1,10 +1,10 @@
-import { AnswersHeadless, UniversalLimit, VerticalResults as VerticalResultsModel } from '@yext/answers-headless-react';
+import { AnswersHeadless, UniversalLimit, VerticalResults as VerticalResultsData } from '@yext/answers-headless-react';
 import { useState } from 'react';
 import useComponentMountStatus from './useComponentMountStatus';
 import useDebouncedFunction from './useDebouncedFunction';
 
 interface EntityPreviewsState {
-  verticalResultsArray: VerticalResultsModel[],
+  verticalResultsArray: VerticalResultsData[],
   isLoading: boolean
 }
 
@@ -26,7 +26,7 @@ export function useEntityPreviews(
   debounceTime: number
 ): [ EntityPreviewsState, ExecuteEntityPreviewsQuery ] {
   const isMountedRef = useComponentMountStatus();
-  const [verticalResultsArray, setVerticalResultsArray] = useState<VerticalResultsModel[]>([]);
+  const [verticalResultsArray, setVerticalResultsArray] = useState<VerticalResultsData[]>([]);
   const debouncedUniversalSearch = useDebouncedFunction(async () => {
     if (!entityPreviewSearcher) {
       return;


### PR DESCRIPTION
The VerticalResults component conflicts with the VerticalResults data model from Answers Core. Rename imports to VerticalResultsModel (following what we have now with DirectAnswerModel)

J=SLAP-1900
TEST=none