### PR TITLE
Update FilterSearch props

### DIFF
--- a/docs/answers-react-components.filtersearchprops.label.md
+++ b/docs/answers-react-components.filtersearchprops.label.md
@@ -4,10 +4,10 @@
 
 ## FilterSearchProps.label property
 
-The display label for the component.
+The display label for the component. Defaults to "Filter".
 
 <b>Signature:</b>
 
 ```typescript
-label: string;
+label?: string;
 ```

--- a/docs/answers-react-components.filtersearchprops.md
+++ b/docs/answers-react-components.filtersearchprops.md
@@ -18,7 +18,7 @@ export interface FilterSearchProps
 |  --- | --- | --- |
 |  [cssCompositionMethod?](./answers-react-components.filtersearchprops.csscompositionmethod.md) | [CompositionMethod](./answers-react-components.compositionmethod.md) | <i>(Optional)</i> The method of combining a component's built-in CSS classes with custom CSS classes. |
 |  [customCssClasses?](./answers-react-components.filtersearchprops.customcssclasses.md) | [FilterSearchCssClasses](./answers-react-components.filtersearchcssclasses.md) | <i>(Optional)</i> CSS classes for customizing the component styling. |
-|  [label](./answers-react-components.filtersearchprops.label.md) | string | The display label for the component. |
+|  [label?](./answers-react-components.filtersearchprops.label.md) | string | <i>(Optional)</i> The display label for the component. Defaults to "Filter". |
 |  [searchFields](./answers-react-components.filtersearchprops.searchfields.md) | Omit&lt;SearchParameterField, 'fetchEntities'&gt;\[\] | An array of fieldApiName and entityType which indicates what to perform the filter search against. |
-|  [sectioned](./answers-react-components.filtersearchprops.sectioned.md) | boolean | Determines whether or not the results of the filter search are separated by field. |
+|  [sectioned?](./answers-react-components.filtersearchprops.sectioned.md) | boolean | <i>(Optional)</i> Determines whether or not the results of the filter search are separated by field. Defaults to false. |
 

--- a/docs/answers-react-components.filtersearchprops.sectioned.md
+++ b/docs/answers-react-components.filtersearchprops.sectioned.md
@@ -4,10 +4,10 @@
 
 ## FilterSearchProps.sectioned property
 
-Determines whether or not the results of the filter search are separated by field.
+Determines whether or not the results of the filter search are separated by field. Defaults to false.
 
 <b>Signature:</b>
 
 ```typescript
-sectioned: boolean;
+sectioned?: boolean;
 ```

--- a/etc/answers-react-components.api.md
+++ b/etc/answers-react-components.api.md
@@ -373,9 +373,9 @@ export interface FilterSearchCssClasses extends AutocompleteResultCssClasses {
 export interface FilterSearchProps {
     cssCompositionMethod?: CompositionMethod;
     customCssClasses?: FilterSearchCssClasses;
-    label: string;
+    label?: string;
     searchFields: Omit<SearchParameterField, 'fetchEntities'>[];
-    sectioned: boolean;
+    sectioned?: boolean;
 }
 
 // @public

--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -43,10 +43,10 @@ const builtInCssClasses: FilterSearchCssClasses = {
  * @public
  */
 export interface FilterSearchProps {
-  /** The display label for the component. */
-  label: string,
-  /** Determines whether or not the results of the filter search are separated by field. */
-  sectioned: boolean,
+  /** The display label for the component. Defaults to "Filter". */
+  label?: string,
+  /** Determines whether or not the results of the filter search are separated by field. Defaults to false. */
+  sectioned?: boolean,
   /** An array of fieldApiName and entityType which indicates what to perform the filter search against. */
   searchFields: Omit<SearchParameterField, 'fetchEntities'>[],
   /** CSS classes for customizing the component styling. */
@@ -64,8 +64,8 @@ export interface FilterSearchProps {
  * @returns A react component for Filter Search
  */
 export function FilterSearch({
-  label,
-  sectioned,
+  label = 'Filter',
+  sectioned = false,
   searchFields,
   customCssClasses,
   cssCompositionMethod


### PR DESCRIPTION
Make `label` and `sectioned` optional and have them default to "Filter" and false, respectively.

J=SLAP-1908
TEST=manual

Use FilterSearch component in the starter app and check that the props behave as expected.