### PR TITLE
Switch from blue to primary color

### DIFF
--- a/src/components/AlternativeVerticals.tsx
+++ b/src/components/AlternativeVerticals.tsx
@@ -31,13 +31,13 @@ const builtInCssClasses: AlternativeVerticalsCssClasses = {
   alternativeVerticals___loading: 'opacity-50',
   noResultsText: 'text-lg text-gray-900 pb-2',
   categoriesText: 'text-gray-500',
-  suggestions: 'pt-4 text-blue-600',
+  suggestions: 'pt-4 text-primary-600',
   suggestionList: 'pt-4',
   suggestion: 'pb-4',
   suggestionButton: 'inline-flex items-center cursor-pointer hover:underline focus:underline',
   verticalIcon: 'w-4 mr-2',
   verticalLink: 'font-bold',
-  allCategoriesLink: 'text-blue-600 cursor-pointer hover:underline focus:underline'
+  allCategoriesLink: 'text-primary-600 cursor-pointer hover:underline focus:underline'
 };
 
 interface VerticalSuggestion {

--- a/src/components/DirectAnswer.tsx
+++ b/src/components/DirectAnswer.tsx
@@ -54,9 +54,9 @@ const builtInCssClasses: DirectAnswerCssClasses = {
   content: '',
   fieldValueDescription: 'font-bold text-xl text-gray-800',
   featuredSnippetDescription: '',
-  viewDetailsLink: 'text-blue-600',
+  viewDetailsLink: 'text-primary-600',
   viewDetailsLinkContainer: 'pt-4 text-gray-500',
-  highlighted: 'bg-blue-100',
+  highlighted: 'bg-primary-100',
   answerContainer: 'p-4 border rounded-lg shadow-sm',
 };
 

--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -30,7 +30,7 @@ const builtInCssClasses: FilterSearchCssClasses = {
   container: 'mb-2',
   label: 'mb-4 text-sm font-medium text-gray-900',
   dropdownContainer: 'absolute z-10 shadow-lg rounded-md border border-gray-300 bg-white pt-3 pb-1 px-4 mt-1',
-  inputElement: 'text-sm bg-white outline-none h-9 w-full p-2 rounded-md border border-gray-300 focus:border-blue-600',
+  inputElement: 'text-sm bg-white outline-none h-9 w-full p-2 rounded-md border border-gray-300 focus:border-primary-600',
   sectionContainer: 'pb-2',
   sectionLabel: 'text-sm text-gray-700 font-semibold pb-2',
   focusedOption: 'bg-gray-100',

--- a/src/components/Filters/CheckboxOption.tsx
+++ b/src/components/Filters/CheckboxOption.tsx
@@ -44,7 +44,7 @@ export interface CheckboxCssClasses {
 
 const builtInCssClasses: CheckboxCssClasses = {
   label: 'text-gray-500 text-sm font-normal cursor-pointer',
-  input: 'w-3.5 h-3.5 form-checkbox cursor-pointer border border-gray-300 rounded-sm text-blue-600 focus:ring-blue-500',
+  input: 'w-3.5 h-3.5 form-checkbox cursor-pointer border border-gray-300 rounded-sm text-primary-600 focus:ring-primary-500',
   container: 'flex items-center space-x-3'
 };
 

--- a/src/components/Filters/SearchInput.tsx
+++ b/src/components/Filters/SearchInput.tsx
@@ -22,7 +22,7 @@ export interface SearchInputProps {
  */
 export function SearchInput(props: SearchInputProps): JSX.Element {
   const {
-    className = 'text-sm bg-white h-9 w-full outline-none p-2 mb-2 rounded-md border border-gray-300 focus:border-blue-600',
+    className = 'text-sm bg-white h-9 w-full outline-none p-2 mb-2 rounded-md border border-gray-300 focus:border-primary-600',
     placeholderText = 'Search here...'
   } = props;
   const { searchValue, setSearchValue } = useFilterGroupContext();

--- a/src/components/LocationBias.tsx
+++ b/src/components/LocationBias.tsx
@@ -17,7 +17,7 @@ export interface LocationBiasCssClasses {
 const builtInCssClasses: LocationBiasCssClasses = {
   container: 'text-sm text-gray-500 text-center m-auto',
   location: 'font-semibold',
-  button: 'text-blue-600 cursor-pointer hover:underline focus:underline',
+  button: 'text-primary-600 cursor-pointer hover:underline focus:underline',
 };
 
 /**

--- a/src/components/SpellCheck.tsx
+++ b/src/components/SpellCheck.tsx
@@ -19,7 +19,7 @@ const builtInCssClasses: SpellCheckCssClasses = {
   container: 'text-lg pb-3',
   helpText: 'text-gray-600',
   spellCheck___loading: 'opacity-50',
-  link: 'text-blue-600 font-bold cursor-pointer hover:underline focus:underline'
+  link: 'text-primary-600 font-bold cursor-pointer hover:underline focus:underline'
 };
 
 /**

--- a/src/components/VerticalResults.tsx
+++ b/src/components/VerticalResults.tsx
@@ -94,7 +94,7 @@ const builtInPaginationCssClasses: PaginationCssClasses = {
   container: 'flex justify-center mb-4',
   labelContainer: 'inline-flex shadow-sm -space-x-px',
   label: 'z-0 inline-flex items-center px-4 py-2 text-sm font-semibold border border-gray-300 text-gray-500',
-  selectedLabel: 'z-10 inline-flex items-center px-4 py-2 text-sm font-semibold border border-blue-600 text-blue-600 bg-blue-50',
+  selectedLabel: 'z-10 inline-flex items-center px-4 py-2 text-sm font-semibold border border-primary-600 text-primary-600 bg-primary-50',
   leftIconContainer: 'inline-flex items-center px-3.5 py-2 border border-gray-300 rounded-l-md',
   rightIconContainer: 'inline-flex items-center px-3.5 py-2 border border-gray-300 rounded-r-md',
   icon: 'w-3 text-gray-500'

--- a/src/components/cards/StandardCard.tsx
+++ b/src/components/cards/StandardCard.tsx
@@ -75,11 +75,11 @@ const builtInCssClasses: StandardCardCssClasses = {
   body: 'flex justify-end pt-2.5 text-base',
   descriptionContainer: 'w-full',
   ctaContainer: 'flex flex-col justify-end ml-4',
-  cta1: 'min-w-max bg-blue-600 text-white font-medium rounded-lg py-2 px-5 shadow',
-  cta2: 'min-w-max bg-white text-blue-600 font-medium rounded-lg py-2 px-5 mt-2 shadow',
+  cta1: 'min-w-max bg-primary-600 text-white font-medium rounded-lg py-2 px-5 shadow',
+  cta2: 'min-w-max bg-white text-primary-600 font-medium rounded-lg py-2 px-5 mt-2 shadow',
   ordinal: 'mr-1.5 text-lg font-medium',
   title: 'text-lg font-medium',
-  titleLink: 'text-lg font-medium text-blue-600 cursor-pointer hover:underline focus:underline',
+  titleLink: 'text-lg font-medium text-primary-600 cursor-pointer hover:underline focus:underline',
   feedbackButtonsContainer: 'flex justify-end mt-4 text-sm text-gray-400 font-medium'
 };
 

--- a/src/sections/SectionHeader.tsx
+++ b/src/sections/SectionHeader.tsx
@@ -25,7 +25,7 @@ const builtInCssClasses: SectionHeaderCssClasses = {
   sectionHeaderIconContainer: 'w-5 h-5',
   sectionHeaderLabel: 'font-bold text-gray-800 text-base pl-3',
   viewMoreContainer: 'flex justify-end flex-grow ml-auto font-medium text-gray-800',
-  viewMoreLink: 'text-blue-600 pr-1 pl-3',
+  viewMoreLink: 'text-primary-600 pr-1 pl-3',
   appliedFiltersContainer: 'ml-3 flex flex-wrap',
   nlpFilter: 'border rounded-3xl px-3 py-1.5 text-sm font-medium text-gray-800 mr-2',
   removableFilter: 'flex items-center border rounded-3xl px-3 py-1.5 text-sm font-medium text-gray-900 mr-2',


### PR DESCRIPTION
Update the usage of the blue color to the custom primary color.

This means that any application using these components must define the primary color in the tailwind config. For example, to use the default blue, the tailwind.config.js should include:

```js
theme: {
    extend: {
        colors: {
            primary: colors.blue,
        }
    }
},
```

The `colors` object must be imported at the top of the config with:
```js
const colors = require('tailwindcss/colors')
```

J=SLAP-1905
TEST=manual

Connect the filter component to the sample app and set the primary color in the config. See the color update on the web page with hot module replacement.