### PR TITLE
Add eslint-plugin-react-perf

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   extends: [
     'plugin:@typescript-eslint/recommended',
-    'plugin:react-hooks/recommended'
+    'plugin:react-hooks/recommended',
+    'plugin:react-perf/recommended'
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
@@ -9,7 +10,8 @@ module.exports = {
     sourceType: 'module'
   },
   plugins: [
-    'eslint-plugin-import'
+    'eslint-plugin-import',
+    'react-perf'
   ],
   rules: {
     indent: ['warn', 2, { SwitchCase: 1 }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint": "^7.30.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-react-hooks": "^4.3.0",
+        "eslint-plugin-react-perf": "^3.3.1",
         "jest": "^27.0.6",
         "msw": "^0.36.8",
         "react": "^17.0.2",
@@ -5144,6 +5145,18 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react-perf": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-perf/-/eslint-plugin-react-perf-3.3.1.tgz",
+      "integrity": "sha512-iOx2UtEOH50TmQhezTS4jbBAj/2gbrUdX+ZM28c2K9mwTvtRX6gdnd2P4WPQrejITDsAMNTCz95zu5HcjCD0xg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.1"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -15262,6 +15275,13 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
       "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-react-perf": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-perf/-/eslint-plugin-react-perf-3.3.1.tgz",
+      "integrity": "sha512-iOx2UtEOH50TmQhezTS4jbBAj/2gbrUdX+ZM28c2K9mwTvtRX6gdnd2P4WPQrejITDsAMNTCz95zu5HcjCD0xg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "^7.30.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "eslint-plugin-react-perf": "^3.3.1",
     "jest": "^27.0.6",
     "msw": "^0.36.8",
     "react": "^17.0.2",


### PR DESCRIPTION
Add the eslint plugin which helps us write more performant React code

A separate item will address the reported problems

J=SLAP-1939
TEST=manual

Run `npm run lint` and see the performance errors and see 51 new problems reported by eslint