### PR TITLE
Add GH Workflow for Percy Snapshots

### DIFF
--- a/.github/workflows/percy-snapshots.yml
+++ b/.github/workflows/percy-snapshots.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
This workflow is run on all pull requests and most pushes. It first generates the Storybook build, which contains the Stories for each Component. Percy then takes this build and generates Snapshots which are uploaded to the `answers-react-components` Project.

J=SLAP-1928
TEST=manual

I tested the steps of the `default-snapshots` job manually and verified that this resulted in the expected Snapshots being uploaded to the Percy Project.