### PR TITLE
remove unneeded cursor-pointer tailwind classes

### DIFF
--- a/src/components/AlternativeVerticals.tsx
+++ b/src/components/AlternativeVerticals.tsx
@@ -34,10 +34,10 @@ const builtInCssClasses: AlternativeVerticalsCssClasses = {
   suggestions: 'pt-4 text-primary-600',
   suggestionList: 'pt-4',
   suggestion: 'pb-4',
-  suggestionButton: 'inline-flex items-center cursor-pointer hover:underline focus:underline',
+  suggestionButton: 'inline-flex items-center hover:underline focus:underline',
   verticalIcon: 'w-4 mr-2',
   verticalLink: 'font-bold',
-  allCategoriesLink: 'text-primary-600 cursor-pointer hover:underline focus:underline'
+  allCategoriesLink: 'text-primary-600 hover:underline focus:underline'
 };
 
 interface VerticalSuggestion {

--- a/src/components/LocationBias.tsx
+++ b/src/components/LocationBias.tsx
@@ -17,7 +17,7 @@ export interface LocationBiasCssClasses {
 const builtInCssClasses: LocationBiasCssClasses = {
   container: 'text-sm text-gray-500 text-center m-auto',
   location: 'font-semibold',
-  button: 'text-primary-600 cursor-pointer hover:underline focus:underline',
+  button: 'text-primary-600 hover:underline focus:underline',
 };
 
 /**

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -54,7 +54,7 @@ const builtInCssClasses: SearchBarCssClasses = {
   searchButtonContainer: ' w-8 h-full mx-2 flex flex-col justify-center items-center',
   searchButton: 'h-7 w-7',
   focusedOption: 'bg-gray-100',
-  clearButton: 'h-3 w-3 mr-3.5 cursor-pointer',
+  clearButton: 'h-3 w-3 mr-3.5',
   verticalDivider: 'mr-0.5',
   recentSearchesOptionContainer: 'flex items-center h-6.5 px-3.5 py-1.5 cursor-pointer hover:bg-gray-100',
   recentSearchesIcon: 'w-5 mr-1 text-gray-300',

--- a/src/components/SpellCheck.tsx
+++ b/src/components/SpellCheck.tsx
@@ -20,7 +20,7 @@ const builtInCssClasses: SpellCheckCssClasses = {
   container: 'text-lg pb-3',
   helpText: 'text-gray-600',
   spellCheck___loading: 'opacity-50',
-  link: 'text-primary-600 font-bold cursor-pointer hover:underline focus:underline'
+  link: 'text-primary-600 font-bold hover:underline focus:underline'
 };
 
 /**

--- a/src/components/cards/StandardCard.tsx
+++ b/src/components/cards/StandardCard.tsx
@@ -79,7 +79,7 @@ const builtInCssClasses: StandardCardCssClasses = {
   cta2: 'min-w-max bg-white text-primary-600 font-medium rounded-lg py-2 px-5 mt-2 shadow',
   ordinal: 'mr-1.5 text-lg font-medium',
   title: 'text-lg font-medium',
-  titleLink: 'text-lg font-medium text-primary-600 cursor-pointer hover:underline focus:underline',
+  titleLink: 'text-lg font-medium text-primary-600 hover:underline focus:underline',
   feedbackButtonsContainer: 'flex justify-end mt-4 text-sm text-gray-400 font-medium'
 };
 


### PR DESCRIPTION
These are not needed for any button or anchor tags.

J=SLAP-1936
TEST=manual

check that anchor and buttons have cursor pointer by default

checked most of these manually, some were harder to get on the page or
hook up to the react-site-search-starter so I did not manually check those