### PR TITLE
tests for useStateUpdatedOnSearch

### DIFF
--- a/tests/__utils__/mocks.ts
+++ b/tests/__utils__/mocks.ts
@@ -10,10 +10,10 @@ export function spyOnActions(): jest.Mocked<AnswersHeadless> {
 
 export type RecursivePartial<T> = {
   [P in keyof T]?:
-    T[P] extends (infer U)[] ? RecursivePartial<U>[] :
+  T[P] extends (infer U)[] ? RecursivePartial<U>[] :
     // eslint-disable-next-line @typescript-eslint/ban-types
     T[P] extends object ? RecursivePartial<T[P]> :
-    T[P];
+      T[P];
 };
 
 export function mockAnswersState(

--- a/tests/hooks/useStateUpdatedOnSearch.test.tsx
+++ b/tests/hooks/useStateUpdatedOnSearch.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, act } from '@testing-library/react';
+import { AnswersHeadlessProvider, useAnswersActions } from '@yext/answers-headless-react';
+import { useStateUpdatedOnSearch } from '../../src/hooks/useStateUpdatedOnSearch';
+
+it('uses the correct initial value', () => {
+  function TestComponent() {
+    const verticalKey = useStateUpdatedOnSearch(state => state.vertical.verticalKey);
+    return <div>{verticalKey}</div>;
+  }
+  renderWithProvider(<TestComponent/>);
+  expect(screen.getByText('initialVerticalKey')).toBeDefined();
+});
+
+describe('updates correctly', () => {
+  function renderTestComponent() {
+    let actions;
+    const TestComponent = () => {
+      const query = useStateUpdatedOnSearch(state => state.query.input) ?? '__';
+      actions = useAnswersActions();
+
+      return <div data-testid='query'>{query}</div>;
+    };
+    renderWithProvider(<TestComponent />);
+    return { actions };
+  }
+
+  it('does not update state before the next search is run', () => {
+    const { actions } = renderTestComponent();
+    expect(screen.getByTestId('query')).toHaveTextContent('__');
+    act(() => actions.setQuery('ignored query update'));
+    expect(screen.getByTestId('query')).toHaveTextContent('__');
+  });
+
+  it('updates state only after searchStatus.isLoading changes from true to false', () => {
+    const { actions } = renderTestComponent();
+    act(() => {
+      actions.setState({
+        ...actions.state,
+        searchStatus: { isLoading: true }
+      });
+      actions.setQuery('updated query');
+    });
+    expect(screen.getByTestId('query')).toHaveTextContent('__');
+    act(() => {
+      actions.setState({
+        ...actions.state,
+        searchStatus: { isLoading: false }
+      });
+    });
+    expect(screen.getByTestId('query')).toHaveTextContent('updated query');
+  });
+});
+
+let headlessIdCounter = 0;
+function renderWithProvider(testJsx) {
+  const config = {
+    apiKey: '_unused',
+    experienceKey: '_unused',
+    locale: '_unused',
+    verticalKey: 'initialVerticalKey',
+    // A unique headlessId is necessary every time a new test is run
+    // Otherwise, the same headless instance will be returned,
+    // even with different usages of AnswersHeadlessProvider.
+    headlessId: headlessIdCounter.toString()
+  };
+  headlessIdCounter++;
+
+  render(
+    <AnswersHeadlessProvider {...config}>
+      {testJsx}
+    </AnswersHeadlessProvider>
+  );
+}


### PR DESCRIPTION
I decided to use the real AnswersHeadlessProvider instead of a mocked one.
Using generateMockedStateManager would not work here without essentially re-implementing
the real ReduxStateManager from AnswersHeadless.

This is because we want to write tests that test whether a react component using
useStateUpdatedOnSearch updates. In order to do that, AnswersHeadless needs to be able
to trigger react renders using useState/useReducer hooks. As said before, adding in this behavior
would essentially reimplement ReduxStateManager.

One downside to this is that using the real AnswersHeadless means dealing with real AnswersHeadless
implementation details. In these tests, the headlessId needs to be unique every single time AnswersHeadlessProvider
is called. Otherwise, AnswersHeadless instances end up shared between tests, and state will bleed
through in between different tests. Even with different headlessIds each time, their session tracking states
are automatically linked together. We have not added an option yet in AnswersHeadless to turn this off.
It also does not affect these particularly tests, but it could potentially "trip somebody up" in the future.

J=SLAP-2007
TEST=auto