### PR TITLE
Tweak VA hover state styling

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -44,7 +44,7 @@ import { executeAutocomplete as executeAutocompleteSearch } from '../utils/searc
 const builtInCssClasses: SearchBarCssClasses = {
   container: 'h-12 mb-6',
   inputDivider: 'border-t border-gray-200 mx-2.5',
-  dropdownContainer: 'bg-white pt-4 pb-3 z-10',
+  dropdownContainer: 'bg-white py-4 z-10',
   inputContainer: 'inline-flex items-center justify-between w-full',
   inputDropdownContainer: 'relative z-10 bg-white border rounded-3xl border-gray-200 w-full overflow-hidden',
   inputDropdownContainer___active: 'shadow-lg',


### PR DESCRIPTION
The styling for the hover state was already present. This PR makes a small change to the styling of the `SearchBar` component. By making the top and bottom padding of the `dropdownContainer` consistent, when there is only one dropdown option, the hover background looks centered. Entity preview styling is controlled by users of the `SearchBar` component, such as `SampleVisualSearchBar` in the starter app, so no changes are needed in the component lib to support that.

J=SLAP-1982
TEST=manual

Check the Theme 3.0 test site locally and see that the hover state looks as expected for recent searches and autocomplete suggestions.