### PR TITLE
VerticalResults Storybook

### DIFF
--- a/tests/components/VerticalResults.stories.tsx
+++ b/tests/components/VerticalResults.stories.tsx
@@ -32,27 +32,9 @@ const mockedHeadlessState = {
         },
         source: Source.KnowledgeManager,
         id: 'id1'
-      },
-      {
-        rawData: {
-          name: 'title2',
-          description: 'text2',
-          c_primaryCTA: {
-            link: 'link1',
-            label: 'job1',
-            linkType: 'link'
-          },
-          c_secondaryCTA: {
-            link: 'link2',
-            label: 'job2',
-            linkType: 'link'
-          }
-        },
-        source: Source.KnowledgeManager,
-        id: 'id2'
       }
     ],
-    resultsCount: 2,
+    resultsCount: 5,
     limit: 1
   }
 };


### PR DESCRIPTION
Add 4 stories for VerticalResults:
- when there's no results
- when there's results without pagination component
- when there's results with pagination component
- when it's in loading state

J=SLAP-1993
TEST=manual

start up storybook and see the expected VerticalResults snapshots. The tailwind styling in storybook will be added in another item.
<img width="305" alt="Screen Shot 2022-03-24 at 5 47 41 PM" src="https://user-images.githubusercontent.com/36055303/160015930-742aef75-9641-4272-b1a2-287bb84317d6.png">
