### PR TITLE
Fix react-perf looping errors

### DIFF
--- a/src/components/AppliedFiltersDisplay.tsx
+++ b/src/components/AppliedFiltersDisplay.tsx
@@ -113,7 +113,8 @@ export function AppliedFiltersDisplay(props: AppliedFiltersDisplayProps): JSX.El
       (filter: DisplayableFilter) =>
         <RemovableFilter
           displayName={filter.displayName ?? ''}
-          handleRemoveFilter={() => handleRemoveFilter(filter)}
+          handleRemoveFilter={handleRemoveFilter}
+          filter={filter}
           key={filter.displayName}
           cssClasses={cssClasses}
         />;
@@ -127,7 +128,8 @@ export function AppliedFiltersDisplay(props: AppliedFiltersDisplayProps): JSX.El
       {hierarchicalFacets.map(filter =>
         <RemovableFilter
           key={filter.displayName}
-          handleRemoveFilter={() => handleRemoveHierarchicalFacetOption(filter)}
+          handleRemoveFilter={handleRemoveHierarchicalFacetOption}
+          filter={filter}
           displayName={filter.lastDisplayNameToken}
           cssClasses={cssClasses}
         />
@@ -143,17 +145,19 @@ export function AppliedFiltersDisplay(props: AppliedFiltersDisplayProps): JSX.El
   );
 }
 
-function RemovableFilter({ handleRemoveFilter, displayName, cssClasses }: {
-  handleRemoveFilter: () => void,
+function RemovableFilter<FilterType>({ handleRemoveFilter, filter, displayName, cssClasses }: {
+  handleRemoveFilter: (filter: FilterType) => void,
+  filter: FilterType,
   displayName: string,
   cssClasses: AppliedFiltersCssClasses
 }): JSX.Element {
+  const handleClick = useCallback(() => handleRemoveFilter(filter), [filter, handleRemoveFilter]);
   return (
     <div className={cssClasses.removableFilter}>
       <div className={cssClasses.filterLabel}>{displayName}</div>
       <button
         className={cssClasses.removeFilterButton}
-        onClick={handleRemoveFilter}
+        onClick={handleClick}
         aria-label={`Remove "${displayName}" filter`}>
         <CloseIcon />
       </button>


### PR DESCRIPTION
Fixes most of the errors found from `eslint-plugin-react-perf` that were caused by looping. The only remaining errors are caused by how `itemData` is passed to `DropdownItem` components. This will require a refactor of the `Dropdown` components to remove the `itemData` concept and will be part of a different item.

J=SLAP-1964
TEST=manual

Hook up locally to the Theme 3.0 test site and make sure applied filters work as expected.