### PR TITLE
reset offset on filtersearch option select

### DIFF
--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -92,6 +92,7 @@ export function FilterSearch({
     const displayName = itemData?.displayName as string;
     if (filter && displayName) {
       answersActions.setFilterOption({ ...filter, displayName, selected: true });
+      answersActions.setOffset(0);
       executeSearch(answersActions);
     }
   }, [answersActions]);

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -33,6 +33,7 @@
         "@microsoft/api-extractor": "^7.19.4",
         "@restart/hooks": "^0.4.5",
         "@restart/ui": "^1.0.1",
+        "@tailwindcss/forms": "^0.5.0",
         "@yext/analytics": "^0.2.0-beta.3",
         "@yext/answers-headless-react": "^1.1.0-beta.10",
         "classnames": "^2.3.1",
@@ -52,6 +53,7 @@
         "@storybook/addon-essentials": "^6.4.19",
         "@storybook/addon-interactions": "^6.4.19",
         "@storybook/addon-links": "^6.4.19",
+        "@storybook/addon-postcss": "^2.0.0",
         "@storybook/react": "^6.4.19",
         "@storybook/testing-library": "^0.0.9",
         "@testing-library/jest-dom": "^5.16.1",
@@ -75,6 +77,7 @@
         "msw": "^0.36.8",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "tailwindcss": "^3.0.23",
         "typescript": "~4.4.3"
       },
       "peerDependencies": {
@@ -20136,8 +20139,10 @@
         "@storybook/addon-essentials": "^6.4.19",
         "@storybook/addon-interactions": "^6.4.19",
         "@storybook/addon-links": "^6.4.19",
+        "@storybook/addon-postcss": "^2.0.0",
         "@storybook/react": "^6.4.19",
         "@storybook/testing-library": "^0.0.9",
+        "@tailwindcss/forms": "^0.5.0",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.3",
         "@testing-library/user-event": "^13.5.0",
@@ -20165,6 +20170,7 @@
         "react-dom": "^17.0.2",
         "react-router-dom": "^5.3.0",
         "recent-searches": "^1.0.5",
+        "tailwindcss": "^3.0.23",
         "typescript": "~4.4.3",
         "uuid": "^8.3.2"
       },

--- a/test-site/src/pages/PeoplePage.tsx
+++ b/test-site/src/pages/PeoplePage.tsx
@@ -1,6 +1,7 @@
 import { useAnswersActions } from '@yext/answers-headless-react';
 import {
   AppliedFilters,
+  FilterSearch,
   ResultsCount,
   SearchBar,
   StandardCard,
@@ -23,6 +24,7 @@ export function PeoplePage() {
         <div className='min-w-fit pr-4'>
           <Facets />
           <StaticFilters />
+          <FilterSearch searchFields={[{fieldApiName: 'name', entityType: 'ce_person' }]}/>
         </div>
         <div className='flex-grow'>
           <div className='flex items-baseline'>


### PR DESCRIPTION
reset offset for a fresh search when user select an option on filtersearch.

J=SLAP-2019
TEST=manual

update test-site People page to use FilterSearch. Perform an empty search to receive all the results, click on second results page on pagination, use filterSearch to select Tom M. See that:
without the change: no result is displayed even though results count is 1.
with the change: the expected one result is displayed on page.