### PR TITLE
Add WCAG Accessibility testing to each Story.

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,6 +6,7 @@ module.exports = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
+    '@storybook/addon-a11y',
     {
       name: '@storybook/addon-postcss',
       options: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,4 +8,12 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  a11y: {
+    options: {
+      runOnly: {
+        type: 'tag',
+        values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag2aaa'],
+      }
+    }
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@babel/preset-typescript": "^7.14.5",
         "@percy/cli": "^1.0.0-beta.76",
         "@percy/storybook": "^4.1.0",
+        "@storybook/addon-a11y": "^6.4.20",
         "@storybook/addon-actions": "^6.4.19",
         "@storybook/addon-essentials": "^6.4.19",
         "@storybook/addon-interactions": "^6.4.19",
@@ -3672,6 +3673,314 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "6.4.20",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-6.4.20.tgz",
+      "integrity": "sha512-DNUkSruVgO+r1AAxZGIwlxKRG/58t81tpoIX38S4bqn3U97BkemndrzydQs93SYDks2raoMeEnOwphQP4GTG5A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "6.4.20",
+        "@storybook/api": "6.4.20",
+        "@storybook/channels": "6.4.20",
+        "@storybook/client-logger": "6.4.20",
+        "@storybook/components": "6.4.20",
+        "@storybook/core-events": "6.4.20",
+        "@storybook/csf": "0.0.2--canary.87bc651.0",
+        "@storybook/theming": "6.4.20",
+        "axe-core": "^4.2.0",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "react-sizeme": "^3.0.1",
+        "regenerator-runtime": "^0.13.7",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/addons": {
+      "version": "6.4.20",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.4.20.tgz",
+      "integrity": "sha512-NbsLjDSkE9v2fOr0M7r2hpdYnlYs789ALkXemdTz2y0NUYSPdRfzVVQNXWrgmXivWQRL0aJ3bOjCOc668PPYjg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/api": "6.4.20",
+        "@storybook/channels": "6.4.20",
+        "@storybook/client-logger": "6.4.20",
+        "@storybook/core-events": "6.4.20",
+        "@storybook/csf": "0.0.2--canary.87bc651.0",
+        "@storybook/router": "6.4.20",
+        "@storybook/theming": "6.4.20",
+        "@types/webpack-env": "^1.16.0",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/api": {
+      "version": "6.4.20",
+      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.4.20.tgz",
+      "integrity": "sha512-YatZjb8HlJFE9umDzd7aqabn5oXvAculX76pTZWMxm53GROMZVeICGOYtSasJZYlkv9fLx/Gy/ksrKQnA719ig==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "6.4.20",
+        "@storybook/client-logger": "6.4.20",
+        "@storybook/core-events": "6.4.20",
+        "@storybook/csf": "0.0.2--canary.87bc651.0",
+        "@storybook/router": "6.4.20",
+        "@storybook/semver": "^7.3.2",
+        "@storybook/theming": "6.4.20",
+        "core-js": "^3.8.2",
+        "fast-deep-equal": "^3.1.3",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "regenerator-runtime": "^0.13.7",
+        "store2": "^2.12.0",
+        "telejson": "^5.3.2",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/channels": {
+      "version": "6.4.20",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.4.20.tgz",
+      "integrity": "sha512-BXvI2/bQIvtQ0LPJCEQwrYm0iMkXD0Pu4WuUGfRCbyqhyw6/VnxOP0x92mvFbtBvjHhyNwk9kZloHyI5zJ3STg==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/client-logger": {
+      "version": "6.4.20",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.4.20.tgz",
+      "integrity": "sha512-vbEivQvLQm05tuqSAb4s9RCc82YF1HcAvRneOYUGI7T/wSoijZzauIstKtb3LHEBBYpsELf4hJ3GuE5xZW3wXg==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2",
+        "global": "^4.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/components": {
+      "version": "6.4.20",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.4.20.tgz",
+      "integrity": "sha512-5JN1pqpkvFuwZNF8bKr+BHttmoCoIYL7TOB4tCb/O8Puu5IKXa0fuCGMGVwUNhheR3lKVmV3C+FdEdl1Gt3xXQ==",
+      "dev": true,
+      "dependencies": {
+        "@popperjs/core": "^2.6.0",
+        "@storybook/client-logger": "6.4.20",
+        "@storybook/csf": "0.0.2--canary.87bc651.0",
+        "@storybook/theming": "6.4.20",
+        "@types/color-convert": "^2.0.0",
+        "@types/overlayscrollbars": "^1.12.0",
+        "@types/react-syntax-highlighter": "11.0.5",
+        "color-convert": "^2.0.1",
+        "core-js": "^3.8.2",
+        "fast-deep-equal": "^3.1.3",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "markdown-to-jsx": "^7.1.3",
+        "memoizerific": "^1.11.3",
+        "overlayscrollbars": "^1.13.1",
+        "polished": "^4.0.5",
+        "prop-types": "^15.7.2",
+        "react-colorful": "^5.1.2",
+        "react-popper-tooltip": "^3.1.1",
+        "react-syntax-highlighter": "^13.5.3",
+        "react-textarea-autosize": "^8.3.0",
+        "regenerator-runtime": "^0.13.7",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/core-events": {
+      "version": "6.4.20",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.4.20.tgz",
+      "integrity": "sha512-POizjsPSA4SeBRKaIMpH/M2Mtw3ZPp1hCdIXTxK+S2M1j2rt3ZvNnG2y4IJM+dYjkL1Qwl3WJusa7qcDCS2+dA==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/router": {
+      "version": "6.4.20",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.4.20.tgz",
+      "integrity": "sha512-lwTBtuq9gNywkVs1rye50dPF6pJEGHhZ+2MOTMtASjuM8KIL/wI3OYwRDnDf/98FcinFAeBcEPrEHmV5sAW73w==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "6.4.20",
+        "core-js": "^3.8.2",
+        "fast-deep-equal": "^3.1.3",
+        "global": "^4.4.0",
+        "history": "5.0.0",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "react-router": "^6.0.0",
+        "react-router-dom": "^6.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/theming": {
+      "version": "6.4.20",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.4.20.tgz",
+      "integrity": "sha512-sVGpRYyJHbdme8ozd9AT70VZ24ug6eypAKT7P+cfzImlYJABjmcfaJ+V4rlavoJF1sGnmauJmGoOf40b1U5JZQ==",
+      "dev": true,
+      "dependencies": {
+        "@emotion/core": "^10.1.1",
+        "@emotion/is-prop-valid": "^0.8.6",
+        "@emotion/styled": "^10.0.27",
+        "@storybook/client-logger": "6.4.20",
+        "core-js": "^3.8.2",
+        "deep-object-diff": "^1.1.0",
+        "emotion-theming": "^10.0.27",
+        "global": "^4.4.0",
+        "memoizerific": "^1.11.3",
+        "polished": "^4.0.5",
+        "resolve-from": "^5.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/history": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.0.0.tgz",
+      "integrity": "sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "dev": true,
+      "dependencies": {
+        "history": "^5.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "dev": true,
+      "dependencies": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/react-router-dom/node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/react-router/node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
       }
     },
     "node_modules/@storybook/addon-actions": {
@@ -7337,19 +7646,6 @@
         "eslint-plugin-tsdoc": "^0.2.14"
       }
     },
-    "node_modules/@yext/eslint-plugin-export-star": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@yext/eslint-plugin-export-star/-/eslint-plugin-export-star-1.0.2.tgz",
-      "integrity": "sha512-f7sKv/+6WY1Fydcp5+ns0m+pz9iXFmcV9PVvykJWxlk90/Qs8CpqlPUBgPt/lZC9mQ2TWvenuDg4qVu/i4fXYw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": "^5.7.0",
-        "@typescript-eslint/typescript-estree": "^5.4.0",
-        "eslint-import-resolver-typescript": "^2.5.0",
-        "eslint-module-utils": "^2.7.1"
-      }
-    },
     "node_modules/abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -7842,39 +8138,6 @@
       },
       "engines": {
         "node": ">= 4.5.0"
-      }
-    },
-    "node_modules/autoprefixer": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.4.tgz",
-      "integrity": "sha512-Tm8JxsB286VweiZ5F0anmbyGiNI3v3wGv3mz9W+cxEDYB/6jbnj6GM9H9mK3wIL8ftgl+C07Lcwb8PG5PCCPzA==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "browserslist": "^4.20.2",
-        "caniuse-lite": "^1.0.30001317",
-        "fraction.js": "^4.2.0",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
       }
     },
     "node_modules/axe-core": {
@@ -8723,6 +8986,7 @@
       "version": "4.20.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
       "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9009,6 +9273,7 @@
       "version": "1.0.30001322",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
       "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9485,8 +9750,7 @@
     },
     "node_modules/commander": {
       "version": "2.20.3",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "devOptional": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
@@ -10811,7 +11075,8 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.99",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.99.tgz",
-      "integrity": "sha512-YXMzbvlo6pW12KWw0bj6cIGCJi1Moy8PLCuuzgRzg6WYIcHILK3szU+HHnHFx2b373qRv+cfmHhbmRbatyAbPA=="
+      "integrity": "sha512-YXMzbvlo6pW12KWw0bj6cIGCJi1Moy8PLCuuzgRzg6WYIcHILK3szU+HHnHFx2b373qRv+cfmHhbmRbatyAbPA==",
+      "dev": true
     },
     "node_modules/element-resize-detector": {
       "version": "1.2.4",
@@ -11084,6 +11349,7 @@
     "node_modules/escalade": {
       "version": "3.1.1",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -11280,27 +11546,6 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-import-resolver-typescript": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.7.0.tgz",
-      "integrity": "sha512-MNHS3u5pebvROX4MjGP9coda589ZGfL1SqdxUV4kSrcclfDRWvNE2D+eljbnWVMvWDVRgT89nhscMHPKYGcObQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "^4.3.4",
-        "glob": "^7.2.0",
-        "is-glob": "^4.0.3",
-        "resolve": "^1.22.0",
-        "tsconfig-paths": "^3.14.1"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "*",
-        "eslint-plugin-import": "*"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -11632,17 +11877,6 @@
       },
       "peerDependencies": {
         "eslint": "^7.5.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-tsdoc": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.14.tgz",
-      "integrity": "sha512-fJ3fnZRsdIoBZgzkQjv8vAj6NeeOoFkTfgosj6mKsFjX70QV256sA/wq+y/R2+OL4L8E79VVaVWrPeZnKNe8Ng==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@microsoft/tsdoc": "0.13.2",
-        "@microsoft/tsdoc-config": "0.15.2"
       }
     },
     "node_modules/eslint-scope": {
@@ -12953,19 +13187,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fraction.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
-      "peer": true,
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://www.patreon.com/infusion"
-      }
-    },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
@@ -13095,6 +13316,7 @@
     "node_modules/fsevents": {
       "version": "2.3.2",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -17820,7 +18042,8 @@
     "node_modules/node-releases": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg=="
+      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+      "dev": true
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -17851,6 +18074,7 @@
     "node_modules/normalize-range": {
       "version": "0.1.2",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26906,6 +27130,242 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@storybook/addon-a11y": {
+      "version": "6.4.20",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-6.4.20.tgz",
+      "integrity": "sha512-DNUkSruVgO+r1AAxZGIwlxKRG/58t81tpoIX38S4bqn3U97BkemndrzydQs93SYDks2raoMeEnOwphQP4GTG5A==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "6.4.20",
+        "@storybook/api": "6.4.20",
+        "@storybook/channels": "6.4.20",
+        "@storybook/client-logger": "6.4.20",
+        "@storybook/components": "6.4.20",
+        "@storybook/core-events": "6.4.20",
+        "@storybook/csf": "0.0.2--canary.87bc651.0",
+        "@storybook/theming": "6.4.20",
+        "axe-core": "^4.2.0",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "react-sizeme": "^3.0.1",
+        "regenerator-runtime": "^0.13.7",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "6.4.20",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.4.20.tgz",
+          "integrity": "sha512-NbsLjDSkE9v2fOr0M7r2hpdYnlYs789ALkXemdTz2y0NUYSPdRfzVVQNXWrgmXivWQRL0aJ3bOjCOc668PPYjg==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "6.4.20",
+            "@storybook/channels": "6.4.20",
+            "@storybook/client-logger": "6.4.20",
+            "@storybook/core-events": "6.4.20",
+            "@storybook/csf": "0.0.2--canary.87bc651.0",
+            "@storybook/router": "6.4.20",
+            "@storybook/theming": "6.4.20",
+            "@types/webpack-env": "^1.16.0",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.4.20",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.4.20.tgz",
+          "integrity": "sha512-YatZjb8HlJFE9umDzd7aqabn5oXvAculX76pTZWMxm53GROMZVeICGOYtSasJZYlkv9fLx/Gy/ksrKQnA719ig==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "6.4.20",
+            "@storybook/client-logger": "6.4.20",
+            "@storybook/core-events": "6.4.20",
+            "@storybook/csf": "0.0.2--canary.87bc651.0",
+            "@storybook/router": "6.4.20",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.4.20",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.21",
+            "memoizerific": "^1.11.3",
+            "regenerator-runtime": "^0.13.7",
+            "store2": "^2.12.0",
+            "telejson": "^5.3.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.4.20",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.4.20.tgz",
+          "integrity": "sha512-BXvI2/bQIvtQ0LPJCEQwrYm0iMkXD0Pu4WuUGfRCbyqhyw6/VnxOP0x92mvFbtBvjHhyNwk9kZloHyI5zJ3STg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.4.20",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.4.20.tgz",
+          "integrity": "sha512-vbEivQvLQm05tuqSAb4s9RCc82YF1HcAvRneOYUGI7T/wSoijZzauIstKtb3LHEBBYpsELf4hJ3GuE5xZW3wXg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/components": {
+          "version": "6.4.20",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.4.20.tgz",
+          "integrity": "sha512-5JN1pqpkvFuwZNF8bKr+BHttmoCoIYL7TOB4tCb/O8Puu5IKXa0fuCGMGVwUNhheR3lKVmV3C+FdEdl1Gt3xXQ==",
+          "dev": true,
+          "requires": {
+            "@popperjs/core": "^2.6.0",
+            "@storybook/client-logger": "6.4.20",
+            "@storybook/csf": "0.0.2--canary.87bc651.0",
+            "@storybook/theming": "6.4.20",
+            "@types/color-convert": "^2.0.0",
+            "@types/overlayscrollbars": "^1.12.0",
+            "@types/react-syntax-highlighter": "11.0.5",
+            "color-convert": "^2.0.1",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.21",
+            "markdown-to-jsx": "^7.1.3",
+            "memoizerific": "^1.11.3",
+            "overlayscrollbars": "^1.13.1",
+            "polished": "^4.0.5",
+            "prop-types": "^15.7.2",
+            "react-colorful": "^5.1.2",
+            "react-popper-tooltip": "^3.1.1",
+            "react-syntax-highlighter": "^13.5.3",
+            "react-textarea-autosize": "^8.3.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.4.20",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.4.20.tgz",
+          "integrity": "sha512-POizjsPSA4SeBRKaIMpH/M2Mtw3ZPp1hCdIXTxK+S2M1j2rt3ZvNnG2y4IJM+dYjkL1Qwl3WJusa7qcDCS2+dA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.4.20",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.4.20.tgz",
+          "integrity": "sha512-lwTBtuq9gNywkVs1rye50dPF6pJEGHhZ+2MOTMtASjuM8KIL/wI3OYwRDnDf/98FcinFAeBcEPrEHmV5sAW73w==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "6.4.20",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "history": "5.0.0",
+            "lodash": "^4.17.21",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "react-router": "^6.0.0",
+            "react-router-dom": "^6.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.4.20",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.4.20.tgz",
+          "integrity": "sha512-sVGpRYyJHbdme8ozd9AT70VZ24ug6eypAKT7P+cfzImlYJABjmcfaJ+V4rlavoJF1sGnmauJmGoOf40b1U5JZQ==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.27",
+            "@storybook/client-logger": "6.4.20",
+            "core-js": "^3.8.2",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.27",
+            "global": "^4.4.0",
+            "memoizerific": "^1.11.3",
+            "polished": "^4.0.5",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "history": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/history/-/history-5.0.0.tgz",
+          "integrity": "sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.6"
+          }
+        },
+        "react-router": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+          "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+          "dev": true,
+          "requires": {
+            "history": "^5.2.0"
+          },
+          "dependencies": {
+            "history": {
+              "version": "5.3.0",
+              "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+              "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.7.6"
+              }
+            }
+          }
+        },
+        "react-router-dom": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+          "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+          "dev": true,
+          "requires": {
+            "history": "^5.2.0",
+            "react-router": "6.3.0"
+          },
+          "dependencies": {
+            "history": {
+              "version": "5.3.0",
+              "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+              "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.7.6"
+              }
+            }
+          }
+        }
+      }
+    },
     "@storybook/addon-actions": {
       "version": "6.4.19",
       "integrity": "sha512-GpSvP8xV8GfNkmtGJjfCgaOx6mbjtyTK0aT9FqX9pU0s+KVMmoCTrBh43b7dWrwxxas01yleBK9VpYggzhi/Fw==",
@@ -29563,19 +30023,6 @@
         "eslint-config-react-app": "^7.0.0"
       }
     },
-    "@yext/eslint-plugin-export-star": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@yext/eslint-plugin-export-star/-/eslint-plugin-export-star-1.0.2.tgz",
-      "integrity": "sha512-f7sKv/+6WY1Fydcp5+ns0m+pz9iXFmcV9PVvykJWxlk90/Qs8CpqlPUBgPt/lZC9mQ2TWvenuDg4qVu/i4fXYw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@typescript-eslint/experimental-utils": "^5.7.0",
-        "@typescript-eslint/typescript-estree": "^5.4.0",
-        "eslint-import-resolver-typescript": "^2.5.0",
-        "eslint-module-utils": "^2.7.1"
-      }
-    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -29951,20 +30398,6 @@
       "version": "2.1.2",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
-    },
-    "autoprefixer": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.4.tgz",
-      "integrity": "sha512-Tm8JxsB286VweiZ5F0anmbyGiNI3v3wGv3mz9W+cxEDYB/6jbnj6GM9H9mK3wIL8ftgl+C07Lcwb8PG5PCCPzA==",
-      "peer": true,
-      "requires": {
-        "browserslist": "^4.20.2",
-        "caniuse-lite": "^1.0.30001317",
-        "fraction.js": "^4.2.0",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
-        "postcss-value-parser": "^4.2.0"
-      }
     },
     "axe-core": {
       "version": "4.4.1",
@@ -30631,6 +31064,7 @@
       "version": "4.20.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
       "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001317",
         "electron-to-chromium": "^1.4.84",
@@ -30832,7 +31266,8 @@
     "caniuse-lite": {
       "version": "1.0.30001322",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
-      "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew=="
+      "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==",
+      "dev": true
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -31169,8 +31604,7 @@
     },
     "commander": {
       "version": "2.20.3",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "devOptional": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "common-path-prefix": {
       "version": "3.0.0",
@@ -32258,7 +32692,8 @@
     "electron-to-chromium": {
       "version": "1.4.99",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.99.tgz",
-      "integrity": "sha512-YXMzbvlo6pW12KWw0bj6cIGCJi1Moy8PLCuuzgRzg6WYIcHILK3szU+HHnHFx2b373qRv+cfmHhbmRbatyAbPA=="
+      "integrity": "sha512-YXMzbvlo6pW12KWw0bj6cIGCJi1Moy8PLCuuzgRzg6WYIcHILK3szU+HHnHFx2b373qRv+cfmHhbmRbatyAbPA==",
+      "dev": true
     },
     "element-resize-detector": {
       "version": "1.2.4",
@@ -32490,7 +32925,8 @@
     },
     "escalade": {
       "version": "3.1.1",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -32748,20 +33184,6 @@
         }
       }
     },
-    "eslint-import-resolver-typescript": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.7.0.tgz",
-      "integrity": "sha512-MNHS3u5pebvROX4MjGP9coda589ZGfL1SqdxUV4kSrcclfDRWvNE2D+eljbnWVMvWDVRgT89nhscMHPKYGcObQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "debug": "^4.3.4",
-        "glob": "^7.2.0",
-        "is-glob": "^4.0.3",
-        "resolve": "^1.22.0",
-        "tsconfig-paths": "^3.14.1"
-      }
-    },
     "eslint-module-utils": {
       "version": "2.7.3",
       "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
@@ -33002,17 +33424,6 @@
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.13.0"
-      }
-    },
-    "eslint-plugin-tsdoc": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.14.tgz",
-      "integrity": "sha512-fJ3fnZRsdIoBZgzkQjv8vAj6NeeOoFkTfgosj6mKsFjX70QV256sA/wq+y/R2+OL4L8E79VVaVWrPeZnKNe8Ng==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@microsoft/tsdoc": "0.13.2",
-        "@microsoft/tsdoc-config": "0.15.2"
       }
     },
     "eslint-scope": {
@@ -33928,12 +34339,6 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true
     },
-    "fraction.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
-      "peer": true
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
@@ -34055,6 +34460,7 @@
     "fsevents": {
       "version": "2.3.2",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -37552,7 +37958,8 @@
     "node-releases": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg=="
+      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -37578,7 +37985,8 @@
     },
     "normalize-range": {
       "version": "0.1.2",
-      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
     },
     "npm-run-path": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/preset-typescript": "^7.14.5",
     "@percy/cli": "^1.0.0-beta.76",
     "@percy/storybook": "^4.1.0",
+    "@storybook/addon-a11y": "^6.4.20",
     "@storybook/addon-actions": "^6.4.19",
     "@storybook/addon-essentials": "^6.4.19",
     "@storybook/addon-interactions": "^6.4.19",


### PR DESCRIPTION
This PR adds the `a11y` add-on to our Storybook infrastructure. This add-on allows us to run WCAG tests against the DOM of each of our stories. Currently, the add-on is configured to test against the same WCAG standards that the Theme does. In another PR, I will figure out how to report the WCAG results directly on PRs. 

J=SLAP-2031
TEST=manual

Verified that in the Storybook build/preview there were accessibility reports for each Story.