### PR TITLE
Add Storybook tests for the SearchBar

### DIFF
--- a/tests/__fixtures__/answers-headless.ts
+++ b/tests/__fixtures__/answers-headless.ts
@@ -7,7 +7,7 @@ import {
 import { RecursivePartial } from '../__utils__/mocks';
 import merge from 'lodash/merge';
 
-export function generateMockedHeadless(state: RecursivePartial<State>): AnswersHeadless {
+export function generateMockedHeadless(state?: RecursivePartial<State>): AnswersHeadless {
   const emptyState: State = {
     query: {},
     universal: {},

--- a/tests/components/SearchBar.stories.tsx
+++ b/tests/components/SearchBar.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { ComponentMeta } from '@storybook/react';
+import { AnswersHeadlessContext } from '@yext/answers-headless-react';
+
+import { generateMockedHeadless } from '../__fixtures__/answers-headless';
+import { SearchBar } from '../../src/components';
+import { userEvent, within } from '@storybook/testing-library';
+import { generateMockedAutocompleteService } from '../__fixtures__/core/autocomplete-service';
+
+const mockedAutocompleteResult = {
+  results: [{
+    value: 'query suggestion 1',
+    verticalKeys: ['verticalKey1', 'verticalKey2']
+  }, {
+    value: 'query suggestion 2'
+  }],
+  inputIntents: [],
+  uuid: ''
+};
+
+const meta: ComponentMeta<typeof SearchBar> = {
+  title: 'SearchBar',
+  component: SearchBar,
+  parameters: {
+    answersCoreServices: {
+      autoCompleteService: generateMockedAutocompleteService(mockedAutocompleteResult)
+    }
+  }
+};
+export default meta;
+
+export const Primary = () => {
+  return (
+    <AnswersHeadlessContext.Provider value={generateMockedHeadless()}>
+      <SearchBar />
+    </AnswersHeadlessContext.Provider>
+  );
+};
+
+export const DropdownExpanded = Primary.bind({});
+DropdownExpanded.play = ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  userEvent.type(canvas.getByRole('textbox'), 'recent search 1');
+  userEvent.keyboard('{enter}');
+  userEvent.clear(canvas.getByRole('textbox'));
+  userEvent.type(canvas.getByRole('textbox'), 'recent search 2');
+  userEvent.keyboard('{enter}');
+  userEvent.click(canvas.getByRole('textbox'));
+};


### PR DESCRIPTION
This PR adds Storybook tests for the `SearchBar` component. One story shows the search bar when the dropdown is closed and the other when the dropdown is expanded and showing recent searches, query suggestions, and vertical links.

J=SLAP-2035
TEST=manual

Spin up Storybook locally and check that the search bar looked as expected for both stories.

<img width="523" alt="Screen Shot 2022-04-13 at 7 44 17 PM" src="https://user-images.githubusercontent.com/88398086/163287339-842d1777-2710-46f2-a2bd-a3564b9a224a.png">