### PR TITLE
use tailwind sr-only for ScreenReader

### DIFF
--- a/src/components/ScreenReader.tsx
+++ b/src/components/ScreenReader.tsx
@@ -21,8 +21,7 @@ export function ScreenReader({
         {instructions}
       </div>
       <div
-        //TODO: Investigate tailwindcss 'sr-only'
-        className='absolute p-0 -m-px w-px h-px overflow-hidden whitespace-nowrap border-0'
+        className='sr-only'
         key={announcementKey}
         aria-live='assertive'
       >


### PR DESCRIPTION
use tailwind sr-only for ScreenReader

J=SLAP-1881
TEST=manual

see that css styling for the screen reader text match the previous list of tailwind classnames. The text is still properly hidden and read by screen reader when new set of options from dropdown appears.