### PR TITLE
Reset facets on searches from FilterSearch

### DIFF
--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -102,8 +102,9 @@ export function FilterSearch({
       }
       answersActions.setFilterOption({ ...newFilter, displayName: newDisplayName, selected: true });
       setCurrentFilter(newFilter);
-      answersActions.setOffset(0);
       if (select && searchOnSelect) {
+        answersActions.setOffset(0);
+        answersActions.resetFacets();
         executeSearch(answersActions);
       }
     }

--- a/test-site/src/pages/PeoplePage.tsx
+++ b/test-site/src/pages/PeoplePage.tsx
@@ -29,6 +29,12 @@ export function PeoplePage() {
       <SearchBar />
       <div className='flex'>
         <div className='w-56 shrink-0 mr-5'>
+          <FilterSearch
+            searchFields={[{ fieldApiName: 'name', entityType: 'ce_person' }]}
+            searchOnSelect={true}
+            label='Filters'
+          />
+          <div className='w-full h-px bg-gray-200 my-4' />
           <NumericalFacets searchOnChange={false} />
           <StandardFacets
             searchable={true}
@@ -50,7 +56,6 @@ export function PeoplePage() {
             searchOnChange={false}
           />
           <br />
-          <FilterSearch searchFields={[{ fieldApiName: 'name', entityType: 'ce_person' }]} />
           <ApplyFiltersButton />
         </div>
         <div className='flex-grow'>

--- a/tests/components/FilterSearch.test.tsx
+++ b/tests/components/FilterSearch.test.tsx
@@ -11,6 +11,7 @@ const actions = spyOnActions();
 
 const setFilterOption = jest.fn();
 const setOffset = jest.fn();
+const resetFacets = jest.fn();
 const searchFieldsProp = [{
   fieldApiName: 'name',
   entityType: 'ce_person'
@@ -21,6 +22,7 @@ describe('search with section labels', () => {
     mockAnswersActions({
       setFilterOption,
       setOffset,
+      resetFacets,
       executeFilterSearch: jest.fn().mockResolvedValue(labeledFilterSearchResponse)
     });
   });
@@ -174,12 +176,15 @@ describe('search with section labels', () => {
         expect(setFilterOption).toBeCalledWith(expectedSetFilterOptionParam);
       });
       expect(setOffset).toBeCalledWith(expectedSetOffsetParam);
+      expect(resetFacets).toBeCalled();
 
       const setFilterOptionCallOrder = setFilterOption.mock.invocationCallOrder[0];
       const setOffsetCallOrder = setOffset.mock.invocationCallOrder[0];
+      const resetFacetsCallOrder = resetFacets.mock.invocationCallOrder[0];
       const mockExecuteSearchCallOrder = mockExecuteSearch.mock.invocationCallOrder[0];
       expect(setFilterOptionCallOrder).toBeLessThan(mockExecuteSearchCallOrder);
       expect(setOffsetCallOrder).toBeLessThan(mockExecuteSearchCallOrder);
+      expect(resetFacetsCallOrder).toBeLessThan(mockExecuteSearchCallOrder);
     });
 
     it('does not trigger a search on pressing "enter" if no autocomplete result is selected', async () => {
@@ -193,6 +198,7 @@ describe('search with section labels', () => {
         expect(setFilterOption).not.toBeCalled();
       });
       expect(setOffset).not.toBeCalled();
+      expect(resetFacets).not.toBeCalled();
       expect(mockExecuteSearch).not.toBeCalled();
     });
 
@@ -216,12 +222,15 @@ describe('search with section labels', () => {
       userEvent.click(autocompleteSuggestion);
       expect(setFilterOption).toBeCalledWith(expectedSetFilterOptionParam);
       expect(setOffset).toBeCalledWith(expectedSetOffsetParam);
+      expect(resetFacets).toBeCalled();
 
       const setFilterOptionCallOrder = setFilterOption.mock.invocationCallOrder[0];
       const setOffsetCallOrder = setOffset.mock.invocationCallOrder[0];
+      const resetFacetsCallOrder = setOffset.mock.invocationCallOrder[0];
       const mockExecuteSearchCallOrder = mockExecuteSearch.mock.invocationCallOrder[0];
       expect(setFilterOptionCallOrder).toBeLessThan(mockExecuteSearchCallOrder);
       expect(setOffsetCallOrder).toBeLessThan(mockExecuteSearchCallOrder);
+      expect(resetFacetsCallOrder).toBeLessThan(mockExecuteSearchCallOrder);
     });
   });
 
@@ -244,7 +253,8 @@ describe('search with section labels', () => {
           selected: true
         });
       });
-      expect(setOffset).toBeCalledWith(0);
+      expect(setOffset).not.toHaveBeenCalled();
+      expect(resetFacets).not.toHaveBeenCalled();
       expect(mockExecuteSearch).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
This PR fixes a bug where facets were not being reset when applying a filter from `FilterSearch` with `searchOnSelect=true`. Product wants the behavior to be like conducting a search from the search bar, where facets are cleared. I also moved the `setOffset` call so it is only made when a search is executed, not whenever a filter is selected (e.g. when `searchOnSelect=false`).

J=SLAP-2240
TEST=auto, manual

Check that the updated Jest tests pass. In the test-site, see that before the changes, facets remained when selecting a filter, even if that sometimes led to no results being shown. After the changes, see that facets are removed when selecting a filter from `FilterSearch`.