### PR TITLE
Separate recent searches in verticals

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -219,10 +219,10 @@ export function SearchBar({
   const executeQuery = useCallback(() => {
     if (!hideRecentSearches) {
       const input = answersActions.state.query.input;
-      input && setRecentSearch(input);
+      input && setRecentSearch(input, verticalKey, isVertical);
     }
     executeQueryWithNearMeHandling();
-  }, [answersActions.state.query.input, executeQueryWithNearMeHandling, hideRecentSearches, setRecentSearch]);
+  }, [answersActions.state.query.input, executeQueryWithNearMeHandling, hideRecentSearches, isVertical, setRecentSearch, verticalKey]);
 
   const handleSubmit = useCallback((value?: string, index?: number, itemData?: FocusedItemData) => {
     value !== undefined && answersActions.setQuery(value);

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -200,12 +200,10 @@ export function SearchBar({
     recentSearches,
     setRecentSearch,
     clearRecentSearches,
-    updateRecentSearchesKey
-  ] = useRecentSearches(recentSearchesLimit, isVertical, verticalKey);
+  ] = useRecentSearches(recentSearchesLimit, verticalKey);
   const filteredRecentSearches = recentSearches?.filter(search =>
     answersUtilities.isCloseMatch(search.query, query)
   );
-  updateRecentSearchesKey(isVertical, verticalKey);
 
   useEffect(() => {
     if (hideRecentSearches) {

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -187,7 +187,7 @@ export function SearchBar({
   const query = useAnswersState(state => state.query.input) ?? '';
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses);
   const isVertical = useAnswersState(state => state.meta.searchType) === SearchTypeEnum.Vertical;
-  const verticalKey = useAnswersState(state => state.vertical.verticalKey) || null;
+  const verticalKey = useAnswersState(state => state.vertical.verticalKey);
   const [autocompleteResponse, executeAutocomplete, clearAutocompleteData] = useSynchronizedRequest(
     () => executeAutocompleteSearch(answersActions)
   );

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -39,7 +39,6 @@ import { executeAutocomplete as executeAutocompleteSearch } from '../utils/searc
 import { clearStaticRangeFilters } from '../utils/filterutils';
 import { useMemo } from 'react';
 import { recursivelyMapChildren } from './utils/recursivelyMapChildren';
-import React from 'react';
 
 const builtInCssClasses: Readonly<SearchBarCssClasses> = {
   searchBarContainer: 'h-12 mb-6',

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -199,11 +199,13 @@ export function SearchBar({
   const [
     recentSearches,
     setRecentSearch,
-    clearRecentSearches
-  ] = useRecentSearches(recentSearchesLimit, verticalKey, isVertical);
+    clearRecentSearches,
+    updateRecentSearchesKey
+  ] = useRecentSearches(recentSearchesLimit, isVertical, verticalKey);
   const filteredRecentSearches = recentSearches?.filter(search =>
     answersUtilities.isCloseMatch(search.query, query)
   );
+  updateRecentSearchesKey(isVertical, verticalKey);
 
   useEffect(() => {
     if (hideRecentSearches) {
@@ -219,10 +221,15 @@ export function SearchBar({
   const executeQuery = useCallback(() => {
     if (!hideRecentSearches) {
       const input = answersActions.state.query.input;
-      input && setRecentSearch(input, verticalKey, isVertical);
+      input && setRecentSearch(input);
     }
     executeQueryWithNearMeHandling();
-  }, [answersActions.state.query.input, executeQueryWithNearMeHandling, hideRecentSearches, isVertical, setRecentSearch, verticalKey]);
+  }, [
+    answersActions.state.query.input,
+    executeQueryWithNearMeHandling,
+    hideRecentSearches,
+    setRecentSearch
+  ]);
 
   const handleSubmit = useCallback((value?: string, index?: number, itemData?: FocusedItemData) => {
     value !== undefined && answersActions.setQuery(value);

--- a/src/hooks/useRecentSearches.ts
+++ b/src/hooks/useRecentSearches.ts
@@ -1,57 +1,65 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import RecentSearches, { ISearch } from 'recent-searches';
-
-// export const RECENT_SEARCHES_KEY = '__yxt_recent_searches__';
 
 export function useRecentSearches(
   recentSearchesLimit: number,
   verticalKey: string|null,
   isVertical: boolean
-): [ISearch[]|undefined, (input: string) => void, () => void] {
-  const recentSearchesKey = getRecentSearchesKey();
-  const recentSearchesLimitRef = useRef(recentSearchesLimit);
-  const [ recentSearches, setRecentSeaches ] = useState<RecentSearches>(
-    new RecentSearches({
-      limit: recentSearchesLimit,
-      namespace: recentSearchesKey
-    })
-  );
-  console.log(recentSearches.getRecentSearches());
-
+): [ISearch[]|undefined, (input: string, verticalKey: string|null, isVertical: boolean) => void, () => void] {
+  const [recentSearches, setRecentSeaches] = useState<{ [key: string]: RecentSearches }>({});
+  const [recentVerticalKeys, setRecentVerticalsKeys] = useState<string[]>([]);
   const clearRecentSearches = useCallback(() => {
-    localStorage.removeItem(recentSearchesKey);
-    setRecentSeaches(new RecentSearches({
-      limit: recentSearchesLimit,
-      namespace: recentSearchesKey
-    }));
-    localStorage.removeItem(recentSearchesKey);
-  }, [recentSearchesKey, recentSearchesLimit]);
-
-  const setRecentSearch = useCallback((input: string) => {
-    recentSearches?.setRecentSearch(input);
-  }, [recentSearches]);
-
-  useEffect(() => {
-    if (recentSearchesLimit !== recentSearchesLimitRef.current) {
-      setRecentSeaches(new RecentSearches({
-        limit: recentSearchesLimit,
-        namespace: recentSearchesKey
-      }));
-      recentSearchesLimitRef.current = recentSearchesLimit;
+    setRecentSeaches({});
+    for (const verticalKey in recentVerticalKeys){
+      localStorage.removeItem(verticalKey);
     }
-  }, [recentSearchesKey, recentSearchesLimit]);
+  }, [recentVerticalKeys]);
 
-  function getRecentSearchesKey(): string {
-    if (isVertical) {
-      if (verticalKey) {
-        return `__yxt_recent_searches_${verticalKey}__`;
+  const setRecentSearch = useCallback((input: string, verticalKey: string|null, isVertical: boolean) => {
+    const recentSearchesKey = getRecentSearchesKey(verticalKey, isVertical);
+    if (recentVerticalKeys && recentSearches) {
+      if (recentSearchesKey in recentVerticalKeys) {
+        recentSearches[recentSearchesKey].setRecentSearch(input);
       } else {
-        console.error('No vertical key found on this vertical');
-        return '';
+        const recentSearchesKey = getRecentSearchesKey(verticalKey, isVertical);
+        const newRecentVerticalKeys = recentVerticalKeys.concat(recentSearchesKey);
+        setRecentVerticalsKeys(newRecentVerticalKeys);
+        setRecentSeaches({
+          [recentSearchesKey]: new RecentSearches({
+            limit: recentSearchesLimit,
+            namespace: recentSearchesKey
+          }),
+          ...recentSearches
+        });
+        console.log(recentSearches[recentSearchesKey]);
+        recentSearches[recentSearchesKey].setRecentSearch(input);
       }
-    } else {
-      return '__yxt_recent_searches_universal__';
     }
+  }, [recentSearches, recentSearchesLimit, recentVerticalKeys]);
+
+  // useEffect(() => {
+  //   if (recentSearchesLimit !== recentSearchesLimitRef.current) {
+  //     setRecentSeaches(new RecentSearches({
+  //       limit: recentSearchesLimit,
+  //       namespace: recentSearchesKey
+  //     }));
+  //     recentSearchesLimitRef.current = recentSearchesLimit;
+  //   }
+  // }, [recentSearchesKey, recentSearchesLimit]);
+
+  const recentSearchesKey = getRecentSearchesKey(verticalKey, isVertical);
+  return [recentSearches[recentSearchesKey]?.getRecentSearches(), setRecentSearch, clearRecentSearches];
+}
+
+function getRecentSearchesKey(verticalKey: string|null, isVertical: boolean): string {
+  if (isVertical) {
+    if (verticalKey) {
+      return `__yxt_recent_searches_${verticalKey}__`;
+    } else {
+      console.error('No vertical key found on this vertical');
+      return '';
+    }
+  } else {
+    return '__yxt_recent_searches_universal__';
   }
-  return [recentSearches?.getRecentSearches(), setRecentSearch, clearRecentSearches];
 }

--- a/src/hooks/useRecentSearches.ts
+++ b/src/hooks/useRecentSearches.ts
@@ -1,12 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import RecentSearches, { ISearch } from 'recent-searches';
 
 export function useRecentSearches(
   recentSearchesLimit: number,
   verticalKey: string | null
 ): [ISearch[] | undefined, (input: string) => void, () => void] {
-  const recentSearchesLimitRef = useRef(recentSearchesLimit);
-  const [recentSearchesKey, setRecentSearchesKey] = useState(getRecentSearchesKey(verticalKey));
+  const recentSearchesKey = getRecentSearchesKey(verticalKey);
   const [recentSearches, setRecentSeaches] = useState<RecentSearches>(
     new RecentSearches({
       limit: recentSearchesLimit,
@@ -33,8 +32,6 @@ export function useRecentSearches(
       limit: recentSearchesLimit,
       namespace: newRecentSearchesKey
     }));
-    setRecentSearchesKey(newRecentSearchesKey);
-    recentSearchesLimitRef.current = recentSearchesLimit;
   }, [recentSearchesKey, recentSearchesLimit, verticalKey]);
 
   return [recentSearches?.getRecentSearches(), setRecentSearch, clearRecentSearches];

--- a/src/hooks/useRecentSearches.ts
+++ b/src/hooks/useRecentSearches.ts
@@ -31,7 +31,7 @@ export function useRecentSearches(
       limit: recentSearchesLimit,
       namespace: recentSearchesKey
     }));
-  }, [recentSearchesKey, recentSearchesLimit, verticalKey]);
+  }, [recentSearchesKey, recentSearchesLimit]);
 
   return [recentSearches?.getRecentSearches(), setRecentSearch, clearRecentSearches];
 }

--- a/src/hooks/useRecentSearches.ts
+++ b/src/hooks/useRecentSearches.ts
@@ -1,27 +1,31 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import RecentSearches, { ISearch } from 'recent-searches';
 
-export const RECENT_SEARCHES_KEY = '__yxt_recent_searches__';
+// export const RECENT_SEARCHES_KEY = '__yxt_recent_searches__';
 
 export function useRecentSearches(
-  recentSearchesLimit: number
+  recentSearchesLimit: number,
+  verticalKey: string|null,
+  isVertical: boolean
 ): [ISearch[]|undefined, (input: string) => void, () => void] {
+  const recentSearchesKey = getRecentSearchesKey();
   const recentSearchesLimitRef = useRef(recentSearchesLimit);
   const [ recentSearches, setRecentSeaches ] = useState<RecentSearches>(
     new RecentSearches({
       limit: recentSearchesLimit,
-      namespace: RECENT_SEARCHES_KEY
+      namespace: recentSearchesKey
     })
   );
+  console.log(recentSearches.getRecentSearches());
 
   const clearRecentSearches = useCallback(() => {
-    localStorage.removeItem(RECENT_SEARCHES_KEY);
+    localStorage.removeItem(recentSearchesKey);
     setRecentSeaches(new RecentSearches({
       limit: recentSearchesLimit,
-      namespace: RECENT_SEARCHES_KEY
+      namespace: recentSearchesKey
     }));
-    localStorage.removeItem(RECENT_SEARCHES_KEY);
-  }, [recentSearchesLimit]);
+    localStorage.removeItem(recentSearchesKey);
+  }, [recentSearchesKey, recentSearchesLimit]);
 
   const setRecentSearch = useCallback((input: string) => {
     recentSearches?.setRecentSearch(input);
@@ -31,11 +35,23 @@ export function useRecentSearches(
     if (recentSearchesLimit !== recentSearchesLimitRef.current) {
       setRecentSeaches(new RecentSearches({
         limit: recentSearchesLimit,
-        namespace: RECENT_SEARCHES_KEY
+        namespace: recentSearchesKey
       }));
       recentSearchesLimitRef.current = recentSearchesLimit;
     }
-  }, [recentSearchesLimit]);
+  }, [recentSearchesKey, recentSearchesLimit]);
 
+  function getRecentSearchesKey(): string {
+    if (isVertical) {
+      if (verticalKey) {
+        return `__yxt_recent_searches_${verticalKey}__`;
+      } else {
+        console.error('No vertical key found on this vertical');
+        return '';
+      }
+    } else {
+      return '__yxt_recent_searches_universal__';
+    }
+  }
   return [recentSearches?.getRecentSearches(), setRecentSearch, clearRecentSearches];
 }

--- a/src/hooks/useRecentSearches.ts
+++ b/src/hooks/useRecentSearches.ts
@@ -27,10 +27,9 @@ export function useRecentSearches(
   }, [recentSearches]);
 
   useEffect(() => {
-    const newRecentSearchesKey = getRecentSearchesKey(verticalKey);
     setRecentSeaches(new RecentSearches({
       limit: recentSearchesLimit,
-      namespace: newRecentSearchesKey
+      namespace: recentSearchesKey
     }));
   }, [recentSearchesKey, recentSearchesLimit, verticalKey]);
 

--- a/src/hooks/useRecentSearches.ts
+++ b/src/hooks/useRecentSearches.ts
@@ -3,7 +3,7 @@ import RecentSearches, { ISearch } from 'recent-searches';
 
 export function useRecentSearches(
   recentSearchesLimit: number,
-  verticalKey: string | null
+  verticalKey: string | undefined
 ): [ISearch[] | undefined, (input: string) => void, () => void] {
   const recentSearchesKey = getRecentSearchesKey(verticalKey);
   const [recentSearches, setRecentSeaches] = useState<RecentSearches>(
@@ -36,7 +36,7 @@ export function useRecentSearches(
   return [recentSearches?.getRecentSearches(), setRecentSearch, clearRecentSearches];
 }
 
-function getRecentSearchesKey(verticalKey: string | null): string {
+function getRecentSearchesKey(verticalKey: string | undefined): string {
   if (verticalKey) {
     return `__yxt_recent_searches_${verticalKey}__`;
   } else {

--- a/src/hooks/useRecentSearches.ts
+++ b/src/hooks/useRecentSearches.ts
@@ -28,21 +28,13 @@ export function useRecentSearches(
   }, [recentSearches]);
 
   useEffect(() => {
-    if (recentSearchesLimit !== recentSearchesLimitRef.current) {
-      setRecentSeaches(new RecentSearches({
-        limit: recentSearchesLimit,
-        namespace: recentSearchesKey
-      }));
-      recentSearchesLimitRef.current = recentSearchesLimit;
-    }
     const newRecentSearchesKey = getRecentSearchesKey(verticalKey);
-    if (recentSearchesKey !== newRecentSearchesKey) {
-      setRecentSearchesKey(newRecentSearchesKey);
-      setRecentSeaches(new RecentSearches({
-        limit: recentSearchesLimit,
-        namespace: newRecentSearchesKey
-      }));
-    }
+    setRecentSeaches(new RecentSearches({
+      limit: recentSearchesLimit,
+      namespace: newRecentSearchesKey
+    }));
+    setRecentSearchesKey(newRecentSearchesKey);
+    recentSearchesLimitRef.current = recentSearchesLimit;
   }, [recentSearchesKey, recentSearchesLimit, verticalKey]);
 
   return [recentSearches?.getRecentSearches(), setRecentSearch, clearRecentSearches];

--- a/src/hooks/useRecentSearches.ts
+++ b/src/hooks/useRecentSearches.ts
@@ -3,34 +3,16 @@ import RecentSearches, { ISearch } from 'recent-searches';
 
 export function useRecentSearches(
   recentSearchesLimit: number,
-  isVertical: boolean,
   verticalKey: string | null
-): [
-    ISearch[]|undefined,
-    (input: string) => void,
-    () => void,
-    (isVertical: boolean, verticalKey: string | null) => void
-  ] {
+): [ISearch[] | undefined, (input: string) => void, () => void] {
   const recentSearchesLimitRef = useRef(recentSearchesLimit);
-  const [ recentSearchesKey, setRecentSearchesKey ] = useState(getRecentSearchesKey(isVertical, verticalKey));
-  const [ recentSearches, setRecentSeaches ] = useState<RecentSearches>(
+  const [recentSearchesKey, setRecentSearchesKey] = useState(getRecentSearchesKey(verticalKey));
+  const [recentSearches, setRecentSeaches] = useState<RecentSearches>(
     new RecentSearches({
       limit: recentSearchesLimit,
       namespace: recentSearchesKey
     })
   );
-
-  const updateRecentSearchesKey = useCallback((isVertical: boolean, verticalKey: string | null) => {
-    const newRecentSearchesKey = getRecentSearchesKey(isVertical, verticalKey);
-    if (recentSearchesKey !== newRecentSearchesKey) {
-      setRecentSearchesKey(newRecentSearchesKey);
-      const newRecentSearchObj = new RecentSearches({
-        limit: recentSearchesLimit,
-        namespace: newRecentSearchesKey
-      });
-      setRecentSeaches(newRecentSearchObj);
-    }
-  }, [recentSearchesKey, recentSearchesLimit]);
 
   const clearRecentSearches = useCallback(() => {
     localStorage.removeItem(recentSearchesKey);
@@ -53,19 +35,22 @@ export function useRecentSearches(
       }));
       recentSearchesLimitRef.current = recentSearchesLimit;
     }
-  }, [recentSearchesKey, recentSearchesLimit]);
+    const newRecentSearchesKey = getRecentSearchesKey(verticalKey);
+    if (recentSearchesKey !== newRecentSearchesKey) {
+      setRecentSearchesKey(newRecentSearchesKey);
+      setRecentSeaches(new RecentSearches({
+        limit: recentSearchesLimit,
+        namespace: newRecentSearchesKey
+      }));
+    }
+  }, [recentSearchesKey, recentSearchesLimit, verticalKey]);
 
-  return [recentSearches?.getRecentSearches(), setRecentSearch, clearRecentSearches, updateRecentSearchesKey];
+  return [recentSearches?.getRecentSearches(), setRecentSearch, clearRecentSearches];
 }
 
-function getRecentSearchesKey(isVertical: boolean, verticalKey: string|null): string {
-  if (isVertical) {
-    if (verticalKey) {
-      return `__yxt_recent_searches_${verticalKey}__`;
-    } else {
-      console.error('No vertical key found on this vertical');
-      return '';
-    }
+function getRecentSearchesKey(verticalKey: string | null): string {
+  if (verticalKey) {
+    return `__yxt_recent_searches_${verticalKey}__`;
   } else {
     return '__yxt_recent_searches_universal__';
   }

--- a/tests/hooks/useRecentSearches.test.tsx
+++ b/tests/hooks/useRecentSearches.test.tsx
@@ -4,6 +4,7 @@ import { renderHook } from '@testing-library/react-hooks';
 beforeEach(() => {
   localStorage.clear();
 });
+
 it('returns recent searches', () => {
   const verticalKey = 'people';
   const { result, rerender } = renderHook(() =>

--- a/tests/hooks/useRecentSearches.test.tsx
+++ b/tests/hooks/useRecentSearches.test.tsx
@@ -82,20 +82,9 @@ it('clears searches properly', () => {
   setRecentPeopleSearch('bob');
   setRecentPeopleSearch('carrie');
 
-  verticalKey = 'places';
-  const [, setRecentPlacesSearch, clearPlacesSearches] = result.current;
-  setRecentPlacesSearch('yext');
-
   clearPeopleSearches();
-  clearPlacesSearches();
-
   verticalKey = 'people';
   rerender();
-  let recentSearches = result.current[0];
-  expect(recentSearches?.length).toBe(0);
-
-  verticalKey = 'places';
-  rerender();
-  recentSearches = result.current[0];
+  const recentSearches = result.current[0];
   expect(recentSearches?.length).toBe(0);
 });

--- a/tests/hooks/useRecentSearches.test.tsx
+++ b/tests/hooks/useRecentSearches.test.tsx
@@ -1,40 +1,24 @@
 import { useRecentSearches } from '../../src/hooks/useRecentSearches';
 import { renderHook } from '@testing-library/react-hooks';
 
+beforeEach(() => {
+  localStorage.clear();
+});
 it('returns recent searches', () => {
   const verticalKey = 'people';
   const { result, rerender } = renderHook(() =>
     useRecentSearches(10, verticalKey)
   );
-  const [, setRecentSearch, clearRecentSearches] = result.current;
+  const setRecentSearch = result.current[1];
   setRecentSearch('bob');
   setRecentSearch('carrie');
   setRecentSearch('williard');
 
   rerender();
   const [recentSearches] = result.current;
-  expect(recentSearches?.length).toBe(3);
-  clearRecentSearches();
-});
-
-it('does not carry over old recent searches to a new vertical', () => {
-  let verticalKey = 'people';
-  const { result, rerender } = renderHook(() =>
-    useRecentSearches(10, verticalKey)
-  );
-  const [, setRecentPeopleSearch, clearPeopleSearches] = result.current;
-  setRecentPeopleSearch('bob');
-  setRecentPeopleSearch('carrie');
-  rerender();
-  let recentSearches = result.current[0];
-  expect(recentSearches?.length).toBe(2);
-
-  verticalKey = 'places';
-  rerender();
-  recentSearches = result.current[0];
-  expect(recentSearches?.length).toBe(0);
-
-  clearPeopleSearches();
+  expect(recentSearches?.[0].query).toBe('williard');
+  expect(recentSearches?.[1].query).toBe('carrie');
+  expect(recentSearches?.[2].query).toBe('bob');
 });
 
 it('preserves recent searches when returning to a vertical', () => {
@@ -42,7 +26,7 @@ it('preserves recent searches when returning to a vertical', () => {
   const { result, rerender } = renderHook(() =>
     useRecentSearches(10, verticalKey)
   );
-  const [, setRecentPeopleSearch, clearPeopleSearches] = result.current;
+  const setRecentPeopleSearch = result.current[1];
   setRecentPeopleSearch('bob');
   setRecentPeopleSearch('carrie');
   rerender();
@@ -52,7 +36,7 @@ it('preserves recent searches when returning to a vertical', () => {
   verticalKey = 'places';
   rerender();
   recentSearches = result.current[0];
-  const [, setRecentPlacesSearch, clearPlacesSearches] = result.current;
+  const setRecentPlacesSearch = result.current[1];
   expect(recentSearches?.length).toBe(0);
 
   setRecentPlacesSearch('yext');
@@ -64,9 +48,6 @@ it('preserves recent searches when returning to a vertical', () => {
   rerender();
   recentSearches = result.current[0];
   expect(recentSearches?.length).toBe(2);
-
-  clearPeopleSearches();
-  clearPlacesSearches();
 });
 
 it('clears searches properly', () => {

--- a/tests/hooks/useRecentSearches.test.tsx
+++ b/tests/hooks/useRecentSearches.test.tsx
@@ -98,6 +98,4 @@ it('clears searches properly', () => {
   rerender();
   recentSearches = result.current[0];
   expect(recentSearches?.length).toBe(0);
-
-
 });

--- a/tests/hooks/useRecentSearches.test.tsx
+++ b/tests/hooks/useRecentSearches.test.tsx
@@ -1,0 +1,103 @@
+import { useRecentSearches } from '../../src/hooks/useRecentSearches';
+import { renderHook } from '@testing-library/react-hooks';
+
+it('returns recent searches', () => {
+  const verticalKey = 'people';
+  const { result, rerender } = renderHook(() =>
+    useRecentSearches(10, verticalKey)
+  );
+  const [, setRecentSearch, clearRecentSearches] = result.current;
+  setRecentSearch('bob');
+  setRecentSearch('carrie');
+  setRecentSearch('williard');
+
+  rerender();
+  const [recentSearches] = result.current;
+  expect(recentSearches?.length).toBe(3);
+  clearRecentSearches();
+});
+
+it('does not carry over old recent searches to a new vertical', () => {
+  let verticalKey = 'people';
+  const { result, rerender } = renderHook(() =>
+    useRecentSearches(10, verticalKey)
+  );
+  const [, setRecentPeopleSearch, clearPeopleSearches] = result.current;
+  setRecentPeopleSearch('bob');
+  setRecentPeopleSearch('carrie');
+  rerender();
+  let recentSearches = result.current[0];
+  expect(recentSearches?.length).toBe(2);
+
+  verticalKey = 'places';
+  rerender();
+  recentSearches = result.current[0];
+  expect(recentSearches?.length).toBe(0);
+
+  verticalKey = 'people';
+  rerender();
+  recentSearches = result.current[0];
+  expect(recentSearches?.length).toBe(2);
+  clearPeopleSearches();
+});
+
+it('preserves recent searches when returning to a vertical', () => {
+  let verticalKey = 'people';
+  const { result, rerender } = renderHook(() =>
+    useRecentSearches(10, verticalKey)
+  );
+  const [, setRecentPeopleSearch, clearPeopleSearches] = result.current;
+  setRecentPeopleSearch('bob');
+  setRecentPeopleSearch('carrie');
+  rerender();
+  let recentSearches = result.current[0];
+  expect(recentSearches?.length).toBe(2);
+
+  verticalKey = 'places';
+  rerender();
+  recentSearches = result.current[0];
+  const [, setRecentPlacesSearch, clearPlacesSearches] = result.current;
+  expect(recentSearches?.length).toBe(0);
+
+  setRecentPlacesSearch('yext');
+  rerender();
+  recentSearches = result.current[0];
+  expect(recentSearches?.length).toBe(1);
+
+  verticalKey = 'people';
+  rerender();
+  recentSearches = result.current[0];
+  expect(recentSearches?.length).toBe(2);
+
+  clearPeopleSearches();
+  clearPlacesSearches();
+});
+
+it('clears searches properly', () => {
+  let verticalKey = 'people';
+  const { result, rerender } = renderHook(() =>
+    useRecentSearches(10, verticalKey)
+  );
+  const [, setRecentPeopleSearch, clearPeopleSearches] = result.current;
+  setRecentPeopleSearch('bob');
+  setRecentPeopleSearch('carrie');
+
+  verticalKey = 'places';
+  const [, setRecentPlacesSearch, clearPlacesSearches] = result.current;
+  setRecentPlacesSearch('yext');
+
+  clearPeopleSearches();
+  clearPlacesSearches();
+
+  verticalKey = 'people';
+  rerender();
+  let recentSearches = result.current[0];
+  expect(recentSearches?.length).toBe(0);
+
+  verticalKey = 'places';
+  rerender();
+  recentSearches = result.current[0];
+  expect(recentSearches?.length).toBe(0);
+
+
+});

--- a/tests/hooks/useRecentSearches.test.tsx
+++ b/tests/hooks/useRecentSearches.test.tsx
@@ -34,10 +34,6 @@ it('does not carry over old recent searches to a new vertical', () => {
   recentSearches = result.current[0];
   expect(recentSearches?.length).toBe(0);
 
-  verticalKey = 'people';
-  rerender();
-  recentSearches = result.current[0];
-  expect(recentSearches?.length).toBe(2);
   clearPeopleSearches();
 });
 


### PR DESCRIPTION
This PR allows recent searches to show in verticals and keeps their recent search histories separate.

J=SLAP-2241
TEST=manual, auto

The test site was used to check that recent search histories in different verticals (and in universal) were all kept separate. Jest tests were written for the `useRecentSearches` hook, testing that recent searches appear, that they stay on their own verticals, and that they can be cleared using the returned `clearRecentSearches` function.