### PR TITLE
Update Snyk transitive dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10378,7 +10378,7 @@
         "set-value": "^2.0.0",
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "unset-value": "^2.0.1"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -26586,53 +26586,72 @@
       }
     },
     "node_modules/unset-value": {
-      "version": "1.0.0",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-2.0.1.tgz",
+      "integrity": "sha512-2hvrBfjUE00PkqN+q0XP6yRAOGrR06uSiUoIQGZkc7GxvQ9H7v8quUPNtZjMg4uux69i8HWpIjLPUKwCuRGyNg==",
       "dev": true,
       "dependencies": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "^2.0.2",
+        "isobject": "^4.0.0"
       },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/unset-value/node_modules/get-value": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz",
+      "integrity": "sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/get-value/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/unset-value/node_modules/has-value": {
-      "version": "0.3.1",
-      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-2.0.2.tgz",
+      "integrity": "sha512-ybKOlcRsK2MqrM3Hmz/lQxXHZ6ejzSPzpNabKB45jb5qDgJvKPa3SdapTsTLwEb9WltgWpOmNax7i+DzNOk4TA==",
       "dev": true,
       "dependencies": {
-        "get-value": "^2.0.3",
-        "has-values": "^0.1.4",
-        "isobject": "^2.0.0"
+        "get-value": "^3.0.0",
+        "has-values": "^2.0.1"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
-      "version": "2.1.0",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
-      "dependencies": {
-        "isarray": "1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6"
       }
     },
     "node_modules/unset-value/node_modules/has-values": {
-      "version": "0.1.4",
-      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-2.0.1.tgz",
+      "integrity": "sha512-+QdH3jOmq9P8GfdjFg0eJudqx1FqU62NQJ4P16rOEHeRdl7ckgwn6uqQjzYE0ZoHVV/e5E2esuJ5Gl5+HUW19w==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/unset-value/node_modules/isobject": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/unset-value/node_modules/isarray": {
-      "version": "1.0.0",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
     },
     "node_modules/upath": {
       "version": "1.2.0",
@@ -35676,7 +35695,7 @@
         "set-value": "^2.0.0",
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "unset-value": "^2.0.1"
       }
     },
     "call-bind": {
@@ -48113,42 +48132,55 @@
       "dev": true
     },
     "unset-value": {
-      "version": "1.0.0",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-2.0.1.tgz",
+      "integrity": "sha512-2hvrBfjUE00PkqN+q0XP6yRAOGrR06uSiUoIQGZkc7GxvQ9H7v8quUPNtZjMg4uux69i8HWpIjLPUKwCuRGyNg==",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "^2.0.2",
+        "isobject": "^4.0.0"
       },
       "dependencies": {
-        "has-value": {
-          "version": "0.3.1",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+        "get-value": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz",
+          "integrity": "sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "isobject": "^3.0.1"
           },
           "dependencies": {
             "isobject": {
-              "version": "2.1.0",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "dev": true,
-              "requires": {
-                "isarray": "1.0.0"
-              }
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+              "dev": true
             }
           }
         },
-        "has-values": {
-          "version": "0.1.4",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-          "dev": true
+        "has-value": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-2.0.2.tgz",
+          "integrity": "sha512-ybKOlcRsK2MqrM3Hmz/lQxXHZ6ejzSPzpNabKB45jb5qDgJvKPa3SdapTsTLwEb9WltgWpOmNax7i+DzNOk4TA==",
+          "dev": true,
+          "requires": {
+            "get-value": "^3.0.0",
+            "has-values": "^2.0.1"
+          }
         },
-        "isarray": {
-          "version": "1.0.0",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+        "has-values": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-2.0.1.tgz",
+          "integrity": "sha512-+QdH3jOmq9P8GfdjFg0eJudqx1FqU62NQJ4P16rOEHeRdl7ckgwn6uqQjzYE0ZoHVV/e5E2esuJ5Gl5+HUW19w==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6329,7 +6329,7 @@
         "chalk": "^4.1.0",
         "core-js": "^3.8.2",
         "express": "^4.17.1",
-        "file-system-cache": "^1.0.5",
+        "file-system-cache": "^1.1.0",
         "find-up": "^5.0.0",
         "fork-ts-checker-webpack-plugin": "^6.0.4",
         "fs-extra": "^9.0.1",
@@ -6702,7 +6702,7 @@
         "cpy": "^8.1.2",
         "detect-port": "^1.3.0",
         "express": "^4.17.1",
-        "file-system-cache": "^1.0.5",
+        "file-system-cache": "^1.1.0",
         "fs-extra": "^9.0.1",
         "globby": "^11.0.2",
         "ip": "^1.1.5",
@@ -6959,7 +6959,7 @@
         "css-loader": "^3.6.0",
         "express": "^4.17.1",
         "file-loader": "^6.2.0",
-        "file-system-cache": "^1.0.5",
+        "file-system-cache": "^1.1.0",
         "find-up": "^5.0.0",
         "fs-extra": "^9.0.1",
         "html-webpack-plugin": "^4.0.0",
@@ -14148,44 +14148,48 @@
       }
     },
     "node_modules/file-system-cache": {
-      "version": "1.0.5",
-      "integrity": "sha1-hCWbNqK7uNPW6xAh0xMv/mTP/08=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/file-system-cache/-/file-system-cache-1.1.0.tgz",
+      "integrity": "sha512-IzF5MBq+5CR0jXx5RxPe4BICl/oEhBSXKaL9fLhAXrIfIUS77Hr4vzrYyqYMHN6uTt+BOqi3fDCTjjEBCjERKw==",
       "dev": true,
       "dependencies": {
-        "bluebird": "^3.3.5",
-        "fs-extra": "^0.30.0",
-        "ramda": "^0.21.0"
+        "fs-extra": "^10.1.0",
+        "ramda": "^0.28.0"
       }
     },
     "node_modules/file-system-cache/node_modules/fs-extra": {
-      "version": "0.30.0",
-      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rimraf": "^2.2.8"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/file-system-cache/node_modules/jsonfile": {
-      "version": "2.4.0",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/file-system-cache/node_modules/rimraf": {
-      "version": "2.7.1",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+    "node_modules/file-system-cache/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -20314,14 +20318,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/klaw": {
-      "version": "1.3.1",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.9"
-      }
-    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
@@ -23050,9 +23046,14 @@
       }
     },
     "node_modules/ramda": {
-      "version": "0.21.0",
-      "integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=",
-      "dev": true
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -32563,7 +32564,7 @@
         "chalk": "^4.1.0",
         "core-js": "^3.8.2",
         "express": "^4.17.1",
-        "file-system-cache": "^1.0.5",
+        "file-system-cache": "^1.1.0",
         "find-up": "^5.0.0",
         "fork-ts-checker-webpack-plugin": "^6.0.4",
         "fs-extra": "^9.0.1",
@@ -32823,7 +32824,7 @@
         "cpy": "^8.1.2",
         "detect-port": "^1.3.0",
         "express": "^4.17.1",
-        "file-system-cache": "^1.0.5",
+        "file-system-cache": "^1.1.0",
         "fs-extra": "^9.0.1",
         "globby": "^11.0.2",
         "ip": "^1.1.5",
@@ -33015,7 +33016,7 @@
         "css-loader": "^3.6.0",
         "express": "^4.17.1",
         "file-loader": "^6.2.0",
-        "file-system-cache": "^1.0.5",
+        "file-system-cache": "^1.1.0",
         "find-up": "^5.0.0",
         "fs-extra": "^9.0.1",
         "html-webpack-plugin": "^4.0.0",
@@ -38572,42 +38573,41 @@
       }
     },
     "file-system-cache": {
-      "version": "1.0.5",
-      "integrity": "sha1-hCWbNqK7uNPW6xAh0xMv/mTP/08=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/file-system-cache/-/file-system-cache-1.1.0.tgz",
+      "integrity": "sha512-IzF5MBq+5CR0jXx5RxPe4BICl/oEhBSXKaL9fLhAXrIfIUS77Hr4vzrYyqYMHN6uTt+BOqi3fDCTjjEBCjERKw==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.3.5",
-        "fs-extra": "^0.30.0",
-        "ramda": "^0.21.0"
+        "fs-extra": "^10.1.0",
+        "ramda": "^0.28.0"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "0.30.0",
-          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
           }
         },
         "jsonfile": {
-          "version": "2.4.0",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
           }
         },
-        "rimraf": {
-          "version": "2.7.1",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
         }
       }
     },
@@ -43254,14 +43254,6 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
-    "klaw": {
-      "version": "1.3.1",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.9"
-      }
-    },
     "kleur": {
       "version": "3.0.3",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
@@ -45356,8 +45348,9 @@
       }
     },
     "ramda": {
-      "version": "0.21.0",
-      "integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
       "dev": true
     },
     "randombytes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11327,7 +11327,7 @@
       "dependencies": {
         "@mrmlnc/readdir-enhanced": "^2.2.1",
         "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
+        "glob-parent": "^5.1.2",
         "is-glob": "^4.0.0",
         "merge2": "^1.2.3",
         "micromatch": "^3.1.10"
@@ -11356,26 +11356,6 @@
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cpy/node_modules/glob-parent": {
-      "version": "3.1.0",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      }
-    },
-    "node_modules/cpy/node_modules/glob-parent/node_modules/is-glob": {
-      "version": "3.1.0",
-      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -22296,11 +22276,6 @@
       "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
       "dev": true
     },
-    "node_modules/path-dirname": {
-      "version": "1.0.2",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
@@ -27050,7 +27025,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "glob-parent": "^3.1.0",
+        "glob-parent": "^5.1.2",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
         "is-glob": "^4.0.0",
@@ -27106,28 +27081,6 @@
       },
       "engines": {
         "node": ">= 4.0"
-      }
-    },
-    "node_modules/watchpack-chokidar2/node_modules/glob-parent": {
-      "version": "3.1.0",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      }
-    },
-    "node_modules/watchpack-chokidar2/node_modules/glob-parent/node_modules/is-glob": {
-      "version": "3.1.0",
-      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "is-extglob": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack-chokidar2/node_modules/is-binary-path": {
@@ -36418,7 +36371,7 @@
           "requires": {
             "@mrmlnc/readdir-enhanced": "^2.2.1",
             "@nodelib/fs.stat": "^1.1.2",
-            "glob-parent": "^3.1.0",
+            "glob-parent": "^5.1.2",
             "is-glob": "^4.0.0",
             "merge2": "^1.2.3",
             "micromatch": "^3.1.10"
@@ -36441,25 +36394,6 @@
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true,
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "dev": true,
-              "requires": {
-                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -44864,11 +44798,6 @@
       "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
       "dev": true
     },
-    "path-dirname": {
-      "version": "1.0.2",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
-    },
     "path-exists": {
       "version": "4.0.0",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
@@ -48501,7 +48430,7 @@
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
             "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
+            "glob-parent": "^5.1.2",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",
@@ -48542,27 +48471,6 @@
           "requires": {
             "bindings": "^1.5.0",
             "nan": "^2.12.1"
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "is-extglob": "^2.1.0"
-              }
-            }
           }
         },
         "is-binary-path": {


### PR DESCRIPTION
Multiple transitive dependencies of Storybook were flagged as Snyk vulnerabilities: unset-value, glob-parent, and file-system-cache. I manually edited the package-lock.json to bump the versions of these dependencies. The new versions do not have the Snyk flagged vulnerabilities. In both cases, I had to bump the version to a new major. I read through the release notes for both transitive dependencies and the breaking changes should not impact us. 

TEST=manual

Built and served the Storybook site. Everything worked as expected.