### PR TITLE
remove initialValue in Dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -18,7 +18,6 @@ interface DropdownItemData {
 export interface DropdownProps {
   screenReaderText: string,
   screenReaderInstructions?: string,
-  initialValue?: string,
   parentQuery?: string,
   onSelect?: (value: string, index: number, focusedItemData: Record<string, unknown> | undefined) => void,
   onToggle?: (
@@ -44,7 +43,6 @@ export function Dropdown(props: PropsWithChildren<DropdownProps>): JSX.Element {
     children,
     screenReaderText,
     screenReaderInstructions = 'When autocomplete results are available, use up and down arrows to review and enter to select.',
-    initialValue,
     onSelect,
     onToggle,
     className,
@@ -58,7 +56,7 @@ export function Dropdown(props: PropsWithChildren<DropdownProps>): JSX.Element {
   const [hasTyped, setHasTyped] = useState<boolean>(false);
   const [childrenWithDropdownItemsTransformed, items] = getTransformedChildrenAndItemData(children);
 
-  const inputContext = useInputContextInstance(initialValue);
+  const inputContext = useInputContextInstance();
   const { value, setValue, lastTypedOrSubmittedValue, setLastTypedOrSubmittedValue } = inputContext;
 
   const focusContext = useFocusContextInstance(
@@ -148,9 +146,9 @@ export function Dropdown(props: PropsWithChildren<DropdownProps>): JSX.Element {
   );
 }
 
-function useInputContextInstance(initialValue = ''): InputContextType {
-  const [value, setValue] = useState(initialValue);
-  const [lastTypedOrSubmittedValue, setLastTypedOrSubmittedValue] = useState(initialValue);
+function useInputContextInstance(): InputContextType {
+  const [value, setValue] = useState('');
+  const [lastTypedOrSubmittedValue, setLastTypedOrSubmittedValue] = useState('');
   return {
     value,
     setValue,

--- a/tests/hooks/useRecentSearches.test.tsx
+++ b/tests/hooks/useRecentSearches.test.tsx
@@ -1,5 +1,6 @@
 import { useRecentSearches } from '../../src/hooks/useRecentSearches';
 import { renderHook } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react';
 
 beforeEach(() => {
   localStorage.clear();
@@ -60,7 +61,7 @@ it('clears searches properly', () => {
   setRecentPeopleSearch('bob');
   setRecentPeopleSearch('carrie');
 
-  clearPeopleSearches();
+  act(() => clearPeopleSearches());
   verticalKey = 'people';
   rerender();
   const recentSearches = result.current[0];


### PR DESCRIPTION
InitialValue is not use by FilterSearch or SearchBar. In the case of user want to set an initial value for the search bar, they would set it through answersActions.setQuery() function, which updates on second render, whereas initialValue is set in useState call in useInputContextInstance on first render. This behavior is taken care of by `parentQuery` field already.

J=SLAP-2249