### PR TITLE
FilterSearch: always have option selected

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -75,6 +75,7 @@ export function Dropdown(props: PropsWithChildren<DropdownProps>): JSX.Element {
     focusedItemData,
     screenReaderUUID,
     setHasTyped,
+    updateFocusedItem,
     onToggle,
     onSelect
   );
@@ -172,7 +173,7 @@ function useFocusContextInstance(
     const numItems = items.length;
     let updatedValue;
     if (updatedFocusedIndex === -1 || updatedFocusedIndex >= numItems || numItems === 0) {
-      updatedValue = value ?? lastTypedOrSubmittedValue;
+      updatedValue = value ?? (numItems === 0 ? '' : lastTypedOrSubmittedValue);
       setFocusedIndex(-1);
       setFocusedItemData(undefined);
       setScreenReaderKey(screenReaderKey + 1);
@@ -205,6 +206,7 @@ function useDropdownContextInstance(
   focusedItemData: Record<string, unknown> | undefined,
   screenReaderUUID: string,
   setHasTyped: (boolean) => void,
+  updateFocusedItem: (index: number, value?: string | undefined) => void,
   onToggle?: (
     isActive: boolean,
     prevValue: string,
@@ -218,6 +220,9 @@ function useDropdownContextInstance(
   const toggleDropdown = (willBeOpen: boolean) => {
     if (!willBeOpen) {
       setHasTyped(false);
+      if (index === -1) {
+        updateFocusedItem(0);
+      }
     }
     _toggleDropdown(willBeOpen);
     onToggle?.(willBeOpen, prevValue, value, index, focusedItemData);

--- a/src/components/FilterGroup.tsx
+++ b/src/components/FilterGroup.tsx
@@ -117,8 +117,7 @@ function CheckboxOptions({
   const shouldRenderOption = (
     option: FilterOptionConfig
   ) => {
-    const displayName = option.displayName || option.value.toString();
-    return searchUtilities.isCloseMatch(displayName, searchValue);
+    return searchUtilities.isCloseMatch(option.displayName || option.value.toString(), searchValue);
   };
 
   let displayedOptions = filterOptions.filter(shouldRenderOption).map(o => {

--- a/src/components/FilterGroup.tsx
+++ b/src/components/FilterGroup.tsx
@@ -117,15 +117,15 @@ function CheckboxOptions({
   const shouldRenderOption = (
     option: FilterOptionConfig
   ) => {
-    option.displayName = option.displayName || option.value.toString();
-    return searchUtilities.isCloseMatch(option.displayName, searchValue);
+    const displayName = option.displayName || option.value.toString();
+    return searchUtilities.isCloseMatch(displayName, searchValue);
   };
 
   let displayedOptions = filterOptions.filter(shouldRenderOption).map(o => {
     return (
       <CheckboxOption
         {...o}
-        key={o.displayName}
+        key={o.displayName || o.value.toString()}
         customCssClasses={cssClasses}
       />
     );


### PR DESCRIPTION
The active text in the input should be the first, matching Filter from the `Dropdown`. If there are no Filters, the active text clears to an empty string. 

J=SLAP-2256
TEST=auto, manual

Checked that clicking outside the `Dropdown` followed the guidelines in the Jira item. Will write jest test if time permits before EA.