### PR TITLE
fix styling issue: filterSearch dropdown pushing content down

### DIFF
--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -26,7 +26,7 @@ export interface FilterSearchCssClasses extends AutocompleteResultCssClasses {
 }
 
 const builtInCssClasses: Readonly<FilterSearchCssClasses> = {
-  filterSearchContainer: 'mb-2',
+  filterSearchContainer: 'relative mb-2',
   label: 'mb-4 text-sm font-medium text-neutral-dark',
   inputElement: 'text-sm bg-white outline-none h-9 w-full p-2 rounded-md border border-gray-300 focus:border-primary text-neutral-dark placeholder:text-neutral',
   sectionLabel: 'text-sm text-neutral-dark font-semibold py-2 px-4',
@@ -197,7 +197,7 @@ export function FilterSearch({
         />
         <DropdownMenu>
           {hasResults &&
-            <div className='relative z-10 shadow-lg rounded-md border border-gray-300 bg-white pt-3 pb-1 mt-1'>
+            <div className='absolute z-10 w-full shadow-lg rounded-md border border-gray-300 bg-white pt-3 pb-1 mt-1'>
               {renderDropdownItems()}
             </div>
           }


### PR DESCRIPTION
regression from switching from absolute to relative in [previous pr](https://github.com/yext/search-ui-react/pull/205) when changing filter search styling so the width of the dropdown menu match the width of the input box. However this cause the filter dropdown menu to push the content down when it's active. Setting z-index with relative on an element inside that block will only alter its layer with respect to other elements inside the same block.

This pr update the styling back to using absolute but set the dropdown menu to be relative to the filter search container and use `w-full` to span its width such that it match the width of the input box.

J=SLAP-2282
TEST=manual
Before and after:
<img width="256" alt="Screen Shot 2022-07-26 at 10 41 27 AM" src="https://user-images.githubusercontent.com/36055303/181036226-1f992d9a-8c3a-4aa8-b3c0-0290e835649b.png"><img width="272" alt="Screen Shot 2022-07-26 at 10 40 16 AM" src="https://user-images.githubusercontent.com/36055303/181035936-b8e54908-53d5-4891-9acf-04b5e78589a8.png">