### PR TITLE
use useComposedCssClasses in ApplyFiltersButton

### DIFF
--- a/src/components/ApplyFiltersButton.tsx
+++ b/src/components/ApplyFiltersButton.tsx
@@ -1,5 +1,6 @@
 import { useSearchActions } from '@yext/search-headless-react';
 import { useCallback } from 'react';
+import { useComposedCssClasses } from '../hooks';
 import { clearStaticRangeFilters, getSelectedNumericalFacetFields } from '../utils/filterutils';
 import { executeSearch } from '../utils/search-operations';
 
@@ -42,7 +43,7 @@ export function ApplyFiltersButton({
   customCssClasses,
   label = 'Apply Filters'
 }: ApplyFiltersButtonProps): JSX.Element {
-  const cssClasses = { ...builtInCssClasses, ...customCssClasses };
+  const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses);
   const searchActions = useSearchActions();
   const handleClick = useCallback(() => {
     searchActions.setOffset(0);


### PR DESCRIPTION
Previously, custom styling would replace default styling. use `useComposedCssClasses` to properly merge default tailwind styling with user custom styling.

J=SLAP-2284
TEST=manual

update ApplyFiltersButton in PeoplePage to include `customCssClasses={{ button: "mt-2 text-red-600" }}` and see that the the custom styling is merged with the default instead of replacing it.