### PR TITLE
Add StaticFilters stories

### DIFF
--- a/tests/components/StaticFilters.stories.tsx
+++ b/tests/components/StaticFilters.stories.tsx
@@ -1,0 +1,44 @@
+import { ComponentMeta } from '@storybook/react';
+import { SearchHeadlessContext } from '@yext/search-headless-react';
+import { userEvent, within } from '@storybook/testing-library';
+import { generateMockedHeadless } from '../__fixtures__/search-headless';
+import { staticFilters } from '../__fixtures__/data/filters';
+import { StaticFilters, StaticFiltersProps } from '../../src';
+
+const meta: ComponentMeta<typeof StaticFilters> = {
+  title: 'StaticFilters',
+  component: StaticFilters
+};
+export default meta;
+
+export const Primary = (args: StaticFiltersProps) => {
+  return (
+    <SearchHeadlessContext.Provider value={generateMockedHeadless()}>
+      <StaticFilters
+        fieldId={staticFilters[0].fieldId}
+        title='Puppy Preference'
+        filterOptions={staticFilters}
+        {...args}
+      />
+    </SearchHeadlessContext.Provider>
+  );
+};
+
+Primary.play = ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  userEvent.click(canvas.getByText('Clifford'));
+};
+
+export const Searchable = (args: StaticFiltersProps) => {
+  return (
+    <SearchHeadlessContext.Provider value={generateMockedHeadless()}>
+      <StaticFilters
+        fieldId={staticFilters[0].fieldId}
+        title='Puppy Preference'
+        filterOptions={staticFilters}
+        searchable={true}
+        {...args}
+      />
+    </SearchHeadlessContext.Provider>
+  );
+};

--- a/tests/components/UniversalResults.stories.tsx
+++ b/tests/components/UniversalResults.stories.tsx
@@ -6,6 +6,7 @@ import { generateMockedHeadless } from '../__fixtures__/search-headless';
 import { UniversalResults, UniversalResultsProps } from '../../src/components/UniversalResults';
 import { RecursivePartial } from '../__utils__/mocks';
 import { verticalResults } from '../__fixtures__/data/universalresults';
+import { DefaultRawDataType } from '../../src/models/DefaultRawDataType';
 
 const meta: ComponentMeta<typeof UniversalResults> = {
   title: 'UniversalResults',
@@ -26,7 +27,7 @@ const verticalConfigMap = {
   }
 };
 
-export const Primary = (args: UniversalResultsProps) => {
+export const Primary = (args: UniversalResultsProps<DefaultRawDataType>) => {
   return (
     <SearchHeadlessContext.Provider value={generateMockedHeadless(mockedHeadlessState)}>
       <UniversalResults verticalConfigMap={verticalConfigMap} showAppliedFilters={true} {...args} />
@@ -34,7 +35,7 @@ export const Primary = (args: UniversalResultsProps) => {
   );
 };
 
-export const Loading = (args: UniversalResultsProps) => {
+export const Loading = (args: UniversalResultsProps<DefaultRawDataType>) => {
   return (
     <SearchHeadlessContext.Provider value={generateMockedHeadless({
       ...mockedHeadlessState,

--- a/tests/components/VerticalResults.stories.tsx
+++ b/tests/components/VerticalResults.stories.tsx
@@ -5,6 +5,7 @@ import { SearchHeadlessContext, Source } from '@yext/search-headless-react';
 import { generateMockedHeadless } from '../__fixtures__/search-headless';
 import { VerticalResults, VerticalResultsProps } from '../../src/components/VerticalResults';
 import { StandardCard } from '../../src/components/cards/standard/StandardCard';
+import { DefaultRawDataType } from '../../src/models/DefaultRawDataType';
 
 const meta: ComponentMeta<typeof VerticalResults> = {
   title: 'VerticalResults',
@@ -44,8 +45,8 @@ const mockedHeadlessState = {
   }
 };
 
-export const NoResults = (args: VerticalResultsProps) => {
-  const verticalResultsProps: VerticalResultsProps = {
+export const NoResults = (args: VerticalResultsProps<DefaultRawDataType>) => {
+  const verticalResultsProps: VerticalResultsProps<DefaultRawDataType> = {
     CardComponent: StandardCard
   };
   return (
@@ -55,8 +56,8 @@ export const NoResults = (args: VerticalResultsProps) => {
   );
 };
 
-export const HasResults = (args: VerticalResultsProps) => {
-  const verticalResultsProps: VerticalResultsProps = {
+export const HasResults = (args: VerticalResultsProps<DefaultRawDataType>) => {
+  const verticalResultsProps: VerticalResultsProps<DefaultRawDataType> = {
     CardComponent: StandardCard
   };
   return (
@@ -66,8 +67,8 @@ export const HasResults = (args: VerticalResultsProps) => {
   );
 };
 
-export const Loading = (args: VerticalResultsProps) => {
-  const verticalResultsProps: VerticalResultsProps = {
+export const Loading = (args: VerticalResultsProps<DefaultRawDataType>) => {
+  const verticalResultsProps: VerticalResultsProps<DefaultRawDataType> = {
     CardComponent: StandardCard
   };
   return (


### PR DESCRIPTION
Add 2 stories for `StaticFilters`: one with the default props with an option selected and one with `searchable = true`. Also, fix errors in `UniversalResults` and `VerticalResults` stories now that the props require a type param.

J=SLAP-2286
TEST=manual

Check that the new Percy snapshots look as expected.