### PR TITLE
Fix bug with applying query filters

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -231,7 +231,7 @@ export function SearchBar({
   const handleSubmit = useCallback((value?: string, index?: number, itemData?: FocusedItemData) => {
     value !== undefined && searchActions.setQuery(value);
     searchActions.setOffset(0);
-    searchActions.resetFacets();
+    searchActions.setFacets([]);
     clearStaticRangeFilters(searchActions);
     if (itemData && isVerticalLink(itemData.verticalLink) && onSelectVerticalLink) {
       onSelectVerticalLink({ verticalLink: itemData.verticalLink, querySource: QuerySource.Autocomplete });

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -27,7 +27,7 @@
     },
     "..": {
       "name": "@yext/search-ui-react",
-      "version": "0.2.0-beta.243",
+      "version": "1.0.0-beta.262",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@microsoft/api-documenter": "^7.15.3",
@@ -70,7 +70,7 @@
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/eslint-config-slapshot": "^0.4.0",
-        "@yext/search-headless-react": "^1.4.0-alpha.147",
+        "@yext/search-headless-react": "^1.4.0",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",
         "eslint": "^8.11.0",
@@ -88,7 +88,7 @@
         "typescript": "~4.4.3"
       },
       "peerDependencies": {
-        "@yext/search-headless-react": "^1.4.0-alpha.147",
+        "@yext/search-headless-react": "^1.4.0",
         "react": "^16.14 || ^17 || ^18"
       }
     },
@@ -35313,7 +35313,7 @@
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/analytics": "^0.2.0-beta.3",
         "@yext/eslint-config-slapshot": "^0.4.0",
-        "@yext/search-headless-react": "^1.4.0-alpha.147",
+        "@yext/search-headless-react": "^1.4.0",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",
         "classnames": "^2.3.1",


### PR DESCRIPTION
This PR fixes the bug from [this Slack thread](https://yext.slack.com/archives/C032CKFARGS/p1658949929942189)  where query filters were not being applied except when hot-reloading the page. Applied query filters are not returned in the response if an empty array of facet options is sent in the request. Because facets were de-selected rather than cleared out completely when executing a new search from the search bar, no query filters were applied.

J=none
TEST=manual

Check that the correct filters are applied automatically when searching "Marty", "Bleecker", and "Marty frodo". If they correspond to a facet, then the applied filters are removable and don't get "stuck" as applied. Query filters are only applied again after a new search is run from the search bar.