### PR TITLE
fix edge cases from filtersearch-option pr

### DIFF
--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -112,10 +112,10 @@ export function FilterSearch({
     const newFilter = itemData?.filter as Filter;
     const newDisplayName = itemData?.displayName as string;
     if (newFilter && newDisplayName) {
-      if (currentFilter) {
-        searchActions.setFilterOption({ ...currentFilter, selected: false });
-      }
       if (select) {
+        if (currentFilter) {
+          searchActions.setFilterOption({ ...currentFilter, selected: false });
+        }
         searchActions.setFilterOption({ ...newFilter, displayName: newDisplayName, selected: true });
         setCurrentFilter(newFilter);
         setFilterQuery(newDisplayName);

--- a/tests/components/FilterSearch.test.tsx
+++ b/tests/components/FilterSearch.test.tsx
@@ -442,6 +442,8 @@ it('clears input when old filters are removed', async () => {
     expect(setFilterOption).toHaveBeenCalledWith({ ...deselectedFilter, selected: true });
   });
 
+  userEvent.click(searchBarElement);
+
   const mockDeselectButton = screen.getByRole('button');
   userEvent.click(mockDeselectButton);
 

--- a/tests/components/FilterSearch.test.tsx
+++ b/tests/components/FilterSearch.test.tsx
@@ -442,8 +442,6 @@ it('clears input when old filters are removed', async () => {
     expect(setFilterOption).toHaveBeenCalledWith({ ...deselectedFilter, selected: true });
   });
 
-  userEvent.click(searchBarElement);
-
   const mockDeselectButton = screen.getByRole('button');
   userEvent.click(mockDeselectButton);
 
@@ -453,4 +451,39 @@ it('clears input when old filters are removed', async () => {
   await waitFor(() => {
     expect(searchBarElement).toHaveValue('');
   });
+});
+
+it('toggling the dropdown does not change selected filters', async () => {
+  const setFilterOption = jest.spyOn(SearchHeadless.prototype, 'setFilterOption');
+  const executeFilterSearch = jest
+    .spyOn(SearchHeadless.prototype, 'executeFilterSearch')
+    .mockResolvedValue(labeledFilterSearchResponse);
+
+  render(
+    <div>
+      <SearchHeadlessContext.Provider value={generateMockedHeadless(mockedState)}>
+        <FilterSearch searchFields={searchFieldsProp} />
+      </SearchHeadlessContext.Provider>
+      <div>external div</div>
+    </div>
+  );
+
+  const searchBarElement = screen.getByRole('textbox');
+  const externalDiv = screen.getByText('external div');
+  userEvent.type(searchBarElement, 'first name 1');
+  expect(await screen.findByRole('textbox')).toHaveDisplayValue('first name 1');
+  userEvent.type(searchBarElement, '{enter}');
+
+  await waitFor(() => {
+    expect(executeFilterSearch).toHaveBeenCalled();
+  });
+
+  await waitFor(() => {
+    expect(setFilterOption).toBeCalledTimes(1);
+  });
+
+  userEvent.click(searchBarElement);
+  userEvent.click(externalDiv);
+
+  expect(setFilterOption).toBeCalledTimes(1);
 });


### PR DESCRIPTION
fixed two edge cases that Juliann pointed out
- https://github.com/yext/search-ui-react/pull/256#issuecomment-1205532847
- https://github.com/yext/search-ui-react/pull/256#issuecomment-1205658494

deselecting the filter `onToggle` messed up these two behaviors because it didn't recognize the input in the search filter as a selected filter, and decided not to clear it / keep the filter on the page. 

TEST=auto