### PR TITLE
code coverage percentages job on pull_request event

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
     secrets:
       caller_github_token: ${{ secrets.GITHUB_TOKEN }}
   individual_coverage_percentages:
-    if: ${{ github.event_name != 'push' }}
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     needs: combined_coverage
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,6 +16,7 @@ jobs:
     secrets:
       caller_github_token: ${{ secrets.GITHUB_TOKEN }}
   individual_coverage_percentages:
+    if: ${{ github.event_name != 'push' }}
     runs-on: ubuntu-latest
     needs: combined_coverage
     steps:


### PR DESCRIPTION
Add/update comment for code coverage percentages on pull_request event only.

TEST=manual

made a non dev/ test branch and push the same changes to it. see that the ` individual_coverage_percentages` job was cancelled.
https://github.com/yext/search-ui-react/runs/7694568793?check_suite_focus=true
https://github.com/yext/search-ui-react/tree/test-coverage-githubaction
<img width="689" alt="Screen Shot 2022-08-05 at 11 49 18 AM" src="https://user-images.githubusercontent.com/36055303/183114067-fb1cc987-7ca5-4d04-9675-61a8d396a274.png">
