### PR TITLE
Exclude `src/models` from Jest Coverage Collection.

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "verbose": true,
     "collectCoverage": false,
     "collectCoverageFrom": [
-      "src/**"
+      "src/**",
+      "!src/models/**"
     ],
     "moduleFileExtensions": [
       "js",


### PR DESCRIPTION
This directory contains types and interfaces outlining data models.
There are no function or anything of the like to unit test.

TEST=auto

Re-ran the `test` command and saw this directory excluded from the
coverage collection.