### PR TITLE
Added Dropdown Stories

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -34,7 +34,8 @@ export const parameters = {
         'AlternativeVerticals',
         'SpellCheck',
         'ResultsCount',
-        'LocationBias'
+        'LocationBias',
+        'Dropdown'
       ]
     }
   }

--- a/src/components/Dropdown/DropdownInput.tsx
+++ b/src/components/Dropdown/DropdownInput.tsx
@@ -32,6 +32,7 @@ export function DropdownInput(props: {
   const {
     focusedIndex = -1,
     focusedItemData,
+    focusedValue,
     updateFocusedItem
   } = useFocusContext();
   const [isTyping, setIsTyping] = useState<boolean>(true);
@@ -56,9 +57,11 @@ export function DropdownInput(props: {
       if (focusedIndex >= 0) {
         onSelect?.(value, focusedIndex, focusedItemData);
       }
+      updateFocusedItem(-1, focusedValue ?? undefined);
     }
   }, [
     focusedIndex,
+    focusedValue,
     focusedItemData,
     onSelect,
     onSubmit,

--- a/tests/components/Dropdown.stories.tsx
+++ b/tests/components/Dropdown.stories.tsx
@@ -45,12 +45,37 @@ DropdownExpanded.play = ({ canvasElement }) => {
   userEvent.click(textboxEl);
 };
 
+export const AlwaysSelectExpanded = (args: DropdownProps) => {
+  return (
+    <div className={cssClasses.filterSearchContainer}>
+      <Dropdown {...args} alwaysSelectOption={true}>
+        <DropdownInput className={cssClasses.inputElement} />
+        <DropdownMenu>
+          <div className='absolute z-10 w-full shadow-lg rounded-md border border-gray-300 bg-white pt-2 pb-2 mt-1'>
+            <DropdownItem focusedClassName={cssClasses.focusedOption} className={cssClasses.option} value='item1'>
+              item1
+            </DropdownItem>
+            <DropdownItem focusedClassName={cssClasses.focusedOption} className={cssClasses.option} value='item2'>
+              item2
+            </DropdownItem>
+          </div>
+        </DropdownMenu>
+      </Dropdown>
+    </div>
+  );
+};
+AlwaysSelectExpanded.play = ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const textboxEl = canvas.getByRole('textbox');
+  userEvent.click(textboxEl);
+};
+
 export const DropdownHighlighted = Primary.bind({});
 DropdownHighlighted.play = ({ canvasElement }) => {
   const canvas = within(canvasElement);
   const textboxEl = canvas.getByRole('textbox');
   userEvent.click(textboxEl);
-  userEvent.keyboard('{arrowdown}');
+  userEvent.keyboard('{arrowdown}{arrowdown}');
 };
 
 export const DropdownSelected = Primary.bind({});
@@ -58,6 +83,6 @@ DropdownSelected.play = ({ canvasElement }) => {
   const canvas = within(canvasElement);
   const textboxEl = canvas.getByRole('textbox');
   userEvent.click(textboxEl);
-  userEvent.keyboard('{arrowdown}');
+  userEvent.keyboard('{arrowdown}{arrowdown}');
   userEvent.keyboard('{enter}');
 };

--- a/tests/components/Dropdown.stories.tsx
+++ b/tests/components/Dropdown.stories.tsx
@@ -18,17 +18,22 @@ const cssClasses = {
   option: 'text-sm text-neutral-dark py-1 cursor-pointer hover:bg-gray-100 px-4'
 };
 
+const dropdownItemProps = {
+  focusedClassName: cssClasses.focusedOption,
+  className: cssClasses.option
+};
+
 export const Primary = (args: DropdownProps) => {
   return (
     <div className={cssClasses.filterSearchContainer}>
-      <Dropdown {...args}>
+      <Dropdown {...args} screenReaderText='screen reader text here'>
         <DropdownInput className={cssClasses.inputElement} />
         <DropdownMenu>
           <div className='absolute z-10 w-full shadow-lg rounded-md border border-gray-300 bg-white pt-2 pb-2 mt-1'>
-            <DropdownItem focusedClassName={cssClasses.focusedOption} className={cssClasses.option} value='item1'>
+            <DropdownItem {...dropdownItemProps} value='item1'>
               item1
             </DropdownItem>
-            <DropdownItem focusedClassName={cssClasses.focusedOption} className={cssClasses.option} value='item2'>
+            <DropdownItem {...dropdownItemProps} value='item2'>
               item2
             </DropdownItem>
           </div>
@@ -48,14 +53,14 @@ DropdownExpanded.play = ({ canvasElement }) => {
 export const AlwaysSelectExpanded = (args: DropdownProps) => {
   return (
     <div className={cssClasses.filterSearchContainer}>
-      <Dropdown {...args} alwaysSelectOption={true}>
+      <Dropdown {...args} alwaysSelectOption={true} screenReaderText='screen reader text here'>
         <DropdownInput className={cssClasses.inputElement} />
         <DropdownMenu>
           <div className='absolute z-10 w-full shadow-lg rounded-md border border-gray-300 bg-white pt-2 pb-2 mt-1'>
-            <DropdownItem focusedClassName={cssClasses.focusedOption} className={cssClasses.option} value='item1'>
+            <DropdownItem {...dropdownItemProps} value='item1'>
               item1
             </DropdownItem>
-            <DropdownItem focusedClassName={cssClasses.focusedOption} className={cssClasses.option} value='item2'>
+            <DropdownItem {...dropdownItemProps} value='item2'>
               item2
             </DropdownItem>
           </div>

--- a/tests/components/Dropdown.stories.tsx
+++ b/tests/components/Dropdown.stories.tsx
@@ -48,12 +48,6 @@ DropdownExpanded.play = ({ canvasElement }) => {
   clickTextbox(canvasElement);
 };
 
-export const DropdownHighlighted = Primary.bind({});
-DropdownHighlighted.play = ({ canvasElement }) => {
-  clickTextbox(canvasElement);
-  userEvent.keyboard('{arrowdown}{arrowdown}');
-};
-
 export const DropdownSelected = Primary.bind({});
 DropdownSelected.play = ({ canvasElement }) => {
   clickTextbox(canvasElement);

--- a/tests/components/Dropdown.stories.tsx
+++ b/tests/components/Dropdown.stories.tsx
@@ -48,25 +48,10 @@ DropdownExpanded.play = ({ canvasElement }) => {
   clickTextbox(canvasElement);
 };
 
-export const AlwaysSelectExpanded = (args: DropdownProps) => {
-  return (
-    <div className={cssClasses.filterSearchContainer}>
-      <Dropdown {...args} alwaysSelectOption={true} screenReaderText='screen reader text here'>
-        <DropdownInput className={cssClasses.inputElement} ariaLabel='screen reader text' />
-        <DropdownMenu>
-          <div className='absolute z-10 w-full shadow-lg rounded-md border border-gray-300 bg-white pt-2 pb-2 mt-1'>
-            <DropdownItem {...dropdownItemProps} value='item1'>
-              item1
-            </DropdownItem>
-            <DropdownItem {...dropdownItemProps} value='item2'>
-              item2
-            </DropdownItem>
-          </div>
-        </DropdownMenu>
-      </Dropdown>
-    </div>
-  );
-};
+export const AlwaysSelectExpanded = Primary.bind({});
+AlwaysSelectExpanded.args = {
+  alwaysSelectOption: true
+}
 AlwaysSelectExpanded.play = ({ canvasElement }) => {
   clickTextbox(canvasElement);
 };

--- a/tests/components/Dropdown.stories.tsx
+++ b/tests/components/Dropdown.stories.tsx
@@ -43,12 +43,6 @@ export const Primary = (args: DropdownProps) => {
   );
 };
 
-function clickTextbox(canvasElement) {
-  const canvas = within(canvasElement);
-  const textboxEl = canvas.getByRole('textbox');
-  userEvent.click(textboxEl);
-}
-
 export const DropdownExpanded = Primary.bind({});
 DropdownExpanded.play = ({ canvasElement }) => {
   clickTextbox(canvasElement);
@@ -89,3 +83,9 @@ DropdownSelected.play = ({ canvasElement }) => {
   userEvent.keyboard('{arrowdown}{arrowdown}');
   userEvent.keyboard('{enter}');
 };
+
+function clickTextbox(canvasElement) {
+  const canvas = within(canvasElement);
+  const textboxEl = canvas.getByRole('textbox');
+  userEvent.click(textboxEl);
+}

--- a/tests/components/Dropdown.stories.tsx
+++ b/tests/components/Dropdown.stories.tsx
@@ -7,7 +7,7 @@ import { DropdownMenu } from '../../src/components/Dropdown/DropdownMenu';
 
 const meta: ComponentMeta<typeof Dropdown> = {
   title: 'Dropdown',
-  component: Dropdown,
+  component: Dropdown
 };
 export default meta;
 

--- a/tests/components/Dropdown.stories.tsx
+++ b/tests/components/Dropdown.stories.tsx
@@ -48,14 +48,6 @@ DropdownExpanded.play = ({ canvasElement }) => {
   clickTextbox(canvasElement);
 };
 
-export const AlwaysSelectExpanded = Primary.bind({});
-AlwaysSelectExpanded.args = {
-  alwaysSelectOption: true
-}
-AlwaysSelectExpanded.play = ({ canvasElement }) => {
-  clickTextbox(canvasElement);
-};
-
 export const DropdownHighlighted = Primary.bind({});
 DropdownHighlighted.play = ({ canvasElement }) => {
   clickTextbox(canvasElement);
@@ -67,6 +59,14 @@ DropdownSelected.play = ({ canvasElement }) => {
   clickTextbox(canvasElement);
   userEvent.keyboard('{arrowdown}{arrowdown}');
   userEvent.keyboard('{enter}');
+};
+
+export const AlwaysSelectExpanded = Primary.bind({});
+AlwaysSelectExpanded.args = {
+  alwaysSelectOption: true
+};
+AlwaysSelectExpanded.play = ({ canvasElement }) => {
+  clickTextbox(canvasElement);
 };
 
 function clickTextbox(canvasElement) {

--- a/tests/components/Dropdown.stories.tsx
+++ b/tests/components/Dropdown.stories.tsx
@@ -1,0 +1,63 @@
+import { ComponentMeta } from '@storybook/react';
+import { within, userEvent } from '@storybook/testing-library';
+import { DropdownItem } from '../../src/components';
+import { Dropdown, DropdownProps } from '../../src/components/Dropdown/Dropdown';
+import { DropdownInput } from '../../src/components/Dropdown/DropdownInput';
+import { DropdownMenu } from '../../src/components/Dropdown/DropdownMenu';
+
+const meta: ComponentMeta<typeof Dropdown> = {
+  title: 'Dropdown',
+  component: Dropdown,
+};
+export default meta;
+
+const cssClasses = {
+  filterSearchContainer: 'relative mb-2',
+  inputElement: 'text-sm bg-white outline-none h-9 w-full p-2 rounded-md border border-gray-300 focus:border-primary text-neutral-dark placeholder:text-neutral',
+  focusedOption: 'bg-gray-100 text-sm text-neutral-dark py-1 cursor-pointer hover:bg-gray-100 px-4',
+  option: 'text-sm text-neutral-dark py-1 cursor-pointer hover:bg-gray-100 px-4'
+};
+
+export const Primary = (args: DropdownProps) => {
+  return (
+    <div className={cssClasses.filterSearchContainer}>
+      <Dropdown {...args}>
+        <DropdownInput className={cssClasses.inputElement} />
+        <DropdownMenu>
+          <div className='absolute z-10 w-full shadow-lg rounded-md border border-gray-300 bg-white pt-2 pb-2 mt-1'>
+            <DropdownItem focusedClassName={cssClasses.focusedOption} className={cssClasses.option} value='item1'>
+              item1
+            </DropdownItem>
+            <DropdownItem focusedClassName={cssClasses.focusedOption} className={cssClasses.option} value='item2'>
+              item2
+            </DropdownItem>
+          </div>
+        </DropdownMenu>
+      </Dropdown>
+    </div>
+  );
+};
+
+export const DropdownExpanded = Primary.bind({});
+DropdownExpanded.play = ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const textboxEl = canvas.getByRole('textbox');
+  userEvent.click(textboxEl);
+};
+
+export const DropdownHighlighted = Primary.bind({});
+DropdownHighlighted.play = ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const textboxEl = canvas.getByRole('textbox');
+  userEvent.click(textboxEl);
+  userEvent.keyboard('{arrowdown}');
+};
+
+export const DropdownSelected = Primary.bind({});
+DropdownSelected.play = ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const textboxEl = canvas.getByRole('textbox');
+  userEvent.click(textboxEl);
+  userEvent.keyboard('{arrowdown}');
+  userEvent.keyboard('{enter}');
+};

--- a/tests/components/Dropdown.stories.tsx
+++ b/tests/components/Dropdown.stories.tsx
@@ -43,11 +43,15 @@ export const Primary = (args: DropdownProps) => {
   );
 };
 
-export const DropdownExpanded = Primary.bind({});
-DropdownExpanded.play = ({ canvasElement }) => {
+function clickTextbox(canvasElement) {
   const canvas = within(canvasElement);
   const textboxEl = canvas.getByRole('textbox');
   userEvent.click(textboxEl);
+}
+
+export const DropdownExpanded = Primary.bind({});
+DropdownExpanded.play = ({ canvasElement }) => {
+  clickTextbox(canvasElement);
 };
 
 export const AlwaysSelectExpanded = (args: DropdownProps) => {
@@ -70,24 +74,18 @@ export const AlwaysSelectExpanded = (args: DropdownProps) => {
   );
 };
 AlwaysSelectExpanded.play = ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-  const textboxEl = canvas.getByRole('textbox');
-  userEvent.click(textboxEl);
+  clickTextbox(canvasElement);
 };
 
 export const DropdownHighlighted = Primary.bind({});
 DropdownHighlighted.play = ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-  const textboxEl = canvas.getByRole('textbox');
-  userEvent.click(textboxEl);
+  clickTextbox(canvasElement);
   userEvent.keyboard('{arrowdown}{arrowdown}');
 };
 
 export const DropdownSelected = Primary.bind({});
 DropdownSelected.play = ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-  const textboxEl = canvas.getByRole('textbox');
-  userEvent.click(textboxEl);
+  clickTextbox(canvasElement);
   userEvent.keyboard('{arrowdown}{arrowdown}');
   userEvent.keyboard('{enter}');
 };

--- a/tests/components/Dropdown.stories.tsx
+++ b/tests/components/Dropdown.stories.tsx
@@ -27,7 +27,7 @@ export const Primary = (args: DropdownProps) => {
   return (
     <div className={cssClasses.filterSearchContainer}>
       <Dropdown {...args} screenReaderText='screen reader text here'>
-        <DropdownInput className={cssClasses.inputElement} />
+        <DropdownInput className={cssClasses.inputElement} ariaLabel='screen reader text' />
         <DropdownMenu>
           <div className='absolute z-10 w-full shadow-lg rounded-md border border-gray-300 bg-white pt-2 pb-2 mt-1'>
             <DropdownItem {...dropdownItemProps} value='item1'>
@@ -54,7 +54,7 @@ export const AlwaysSelectExpanded = (args: DropdownProps) => {
   return (
     <div className={cssClasses.filterSearchContainer}>
       <Dropdown {...args} alwaysSelectOption={true} screenReaderText='screen reader text here'>
-        <DropdownInput className={cssClasses.inputElement} />
+        <DropdownInput className={cssClasses.inputElement} ariaLabel='screen reader text' />
         <DropdownMenu>
           <div className='absolute z-10 w-full shadow-lg rounded-md border border-gray-300 bg-white pt-2 pb-2 mt-1'>
             <DropdownItem {...dropdownItemProps} value='item1'>

--- a/tests/components/SearchBar.stories.tsx
+++ b/tests/components/SearchBar.stories.tsx
@@ -81,4 +81,5 @@ function conductRecentSearches(textboxEl: HTMLElement) {
   userEvent.clear(textboxEl);
   userEvent.type(textboxEl, 'recent search 2');
   userEvent.keyboard('{enter}');
+  userEvent.clear(textboxEl);
 }

--- a/tests/components/SearchBar.stories.tsx
+++ b/tests/components/SearchBar.stories.tsx
@@ -81,5 +81,4 @@ function conductRecentSearches(textboxEl: HTMLElement) {
   userEvent.clear(textboxEl);
   userEvent.type(textboxEl, 'recent search 2');
   userEvent.keyboard('{enter}');
-  userEvent.clear(textboxEl);
 }


### PR DESCRIPTION
Added stories for `Dropdown` component. Though it is used in `FilterSearch` and `SearchBar`, we figured it'd be good to have separate stories because users should be able to use `Dropdown` for their own components. `Dropdown` doesn't have any built-in css, so I used the `FilterSearch` css as a reference for styling.

On writing the tests, I found a wcag bug with `DropdownInput` that wasn't setting the `aria-activedescendant` correctly on select. I had to set `focusedIndex` back to `-1` after performing actions related to pressing 'enter'. 

J=SLAP-2320
TEST=auto