### PR TITLE
Static filter state updates

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -406,7 +406,7 @@ Apache License
 
 The following NPM package may be included in this product:
 
- - @reduxjs/toolkit@1.8.3
+ - @reduxjs/toolkit@1.8.4
 
 This package contains the following license and notice below:
 
@@ -758,7 +758,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-core@1.9.0
+ - @yext/search-core@2.0.0-alpha.204
 
 This package contains the following license and notice below:
 
@@ -802,7 +802,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless-react@1.4.0
+ - @yext/search-headless-react@2.0.0-alpha.151
 
 This package contains the following license and notice below:
 
@@ -846,7 +846,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless@1.4.0
+ - @yext/search-headless@2.0.0-alpha.130
 
 This package contains the following license and notice below:
 

--- a/docs/search-ui-react.appliedfilters.md
+++ b/docs/search-ui-react.appliedfilters.md
@@ -4,7 +4,7 @@
 
 ## AppliedFilters() function
 
-A component that displays a list of filters applied to the current vertical search, which may include any selected options from static filters, facets, and NLP filters.
+A component that displays a list of filters applied to the current vertical search, which may include any selected options from facets, NLP filters, and field value static filters.
 
 <b>Signature:</b>
 

--- a/docs/search-ui-react.filtergroupprops.filteroptions.md
+++ b/docs/search-ui-react.filtergroupprops.filteroptions.md
@@ -4,7 +4,7 @@
 
 ## FilterGroupProps.filterOptions property
 
-The configuration data for a filter option.
+The configuration data for a field value filter option.
 
 <b>Signature:</b>
 

--- a/docs/search-ui-react.filtergroupprops.md
+++ b/docs/search-ui-react.filtergroupprops.md
@@ -20,7 +20,7 @@ export interface FilterGroupProps
 |  [customCssClasses?](./search-ui-react.filtergroupprops.customcssclasses.md) | [FilterGroupCssClasses](./search-ui-react.filtergroupcssclasses.md) | <i>(Optional)</i> CSS classes for customizing the component styling. |
 |  [defaultExpanded?](./search-ui-react.filtergroupprops.defaultexpanded.md) | boolean | <i>(Optional)</i> If the filter group is collapsible, whether or not it should start out expanded. Defaults to true. |
 |  [fieldId](./search-ui-react.filtergroupprops.fieldid.md) | string | The fieldId corresponding to the filter group. |
-|  [filterOptions](./search-ui-react.filtergroupprops.filteroptions.md) | [FilterOptionConfig](./search-ui-react.filteroptionconfig.md)<!-- -->\[\] | The configuration data for a filter option. |
+|  [filterOptions](./search-ui-react.filtergroupprops.filteroptions.md) | [FilterOptionConfig](./search-ui-react.filteroptionconfig.md)<!-- -->\[\] | The configuration data for a field value filter option. |
 |  [searchable?](./search-ui-react.filtergroupprops.searchable.md) | boolean | <i>(Optional)</i> Whether or not to display a text input to search for filter options. |
 |  [showMoreLimit?](./search-ui-react.filtergroupprops.showmorelimit.md) | number | <i>(Optional)</i> Limit on the number of options to be displayed. |
 |  [title](./search-ui-react.filtergroupprops.title.md) | string | The displayed label for the filter group. |

--- a/docs/search-ui-react.filteroptionconfig.md
+++ b/docs/search-ui-react.filteroptionconfig.md
@@ -4,7 +4,7 @@
 
 ## FilterOptionConfig interface
 
-The configuration data for a filter option.
+The configuration data for a field value filter option.
 
 <b>Signature:</b>
 

--- a/docs/search-ui-react.filtersearchprops.label.md
+++ b/docs/search-ui-react.filtersearchprops.label.md
@@ -4,7 +4,7 @@
 
 ## FilterSearchProps.label property
 
-The display label for the component. Defaults to "Filter".
+The display label for the component.
 
 <b>Signature:</b>
 

--- a/docs/search-ui-react.filtersearchprops.md
+++ b/docs/search-ui-react.filtersearchprops.md
@@ -17,7 +17,7 @@ export interface FilterSearchProps
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [customCssClasses?](./search-ui-react.filtersearchprops.customcssclasses.md) | [FilterSearchCssClasses](./search-ui-react.filtersearchcssclasses.md) | <i>(Optional)</i> CSS classes for customizing the component styling. |
-|  [label?](./search-ui-react.filtersearchprops.label.md) | string | <i>(Optional)</i> The display label for the component. Defaults to "Filter". |
+|  [label?](./search-ui-react.filtersearchprops.label.md) | string | <i>(Optional)</i> The display label for the component. |
 |  [placeholder?](./search-ui-react.filtersearchprops.placeholder.md) | string | <i>(Optional)</i> The search input's placeholder text when no text has been entered by the user. Defaults to "Search here...". |
 |  [searchFields](./search-ui-react.filtersearchprops.searchfields.md) | Omit&lt;SearchParameterField, 'fetchEntities'&gt;\[\] | An array of fieldApiName and entityType which indicates what to perform the filter search against. |
 |  [searchOnSelect?](./search-ui-react.filtersearchprops.searchonselect.md) | boolean | <i>(Optional)</i> Whether to trigger a search when an option is selected. Defaults to false. |

--- a/docs/search-ui-react.md
+++ b/docs/search-ui-react.md
@@ -10,7 +10,7 @@
 |  --- | --- |
 |  [AlternativeVerticals({ currentVerticalLabel, verticalConfigMap, displayAllOnNoResults, customCssClasses })](./search-ui-react.alternativeverticals.md) | A component that displays the alternative verticals that have results if a search returns none on the current vertical. |
 |  [AnalyticsProvider(props)](./search-ui-react.analyticsprovider.md) | A higher-order component which provides analytics for its children. |
-|  [AppliedFilters(props)](./search-ui-react.appliedfilters.md) | A component that displays a list of filters applied to the current vertical search, which may include any selected options from static filters, facets, and NLP filters. |
+|  [AppliedFilters(props)](./search-ui-react.appliedfilters.md) | A component that displays a list of filters applied to the current vertical search, which may include any selected options from facets, NLP filters, and field value static filters. |
 |  [ApplyFiltersButton({ customCssClasses, label })](./search-ui-react.applyfiltersbutton.md) | Runs a vertical search. By default has <code>position: sticky</code> styling that anchors it to the bottom of the page. |
 |  [DirectAnswer(props)](./search-ui-react.directanswer.md) | Renders Direct Answers provided by the Search API. |
 |  [DropdownItem(\_props)](./search-ui-react.dropdownitem.md) | A wrapper component for specifying a DropdownItemWithIndex. The index will be automatically provided by the Dropdown component instance. |
@@ -32,7 +32,7 @@
 |  [StandardCard(props)](./search-ui-react.standardcard.md) | This Component renders the base result card. |
 |  [StandardFacets(props)](./search-ui-react.standardfacets.md) | A component that displays simple facets applicable to the current vertical search. |
 |  [StandardSection(props)](./search-ui-react.standardsection.md) | A component that displays all the results for a vertical using a standard section template. |
-|  [StaticFilters(props)](./search-ui-react.staticfilters.md) | A component that displays a group of user-configured filters that will be applied to the current vertical search. |
+|  [StaticFilters(props)](./search-ui-react.staticfilters.md) | A component that displays a group of user-configured field value filters that will be applied to the current vertical search. |
 |  [ThumbsFeedback(props)](./search-ui-react.thumbsfeedback.md) | Renders a quality feedback widget composed of thumbs up and thumbs down buttons. |
 |  [UniversalResults({ verticalConfigMap, showAppliedFilters, customCssClasses })](./search-ui-react.universalresults.md) | Displays the results of a universal search with the results for each vertical separated into sections. |
 |  [updateLocationIfNeeded(searchActions, intents, geolocationOptions)](./search-ui-react.updatelocationifneeded.md) | If the provided search intents include a 'NEAR\_ME' intent and there's no existing user's location in state, retrieve and store user's location in headless state. |
@@ -59,7 +59,7 @@
 |  [DirectAnswerProps](./search-ui-react.directanswerprops.md) | Props for [DirectAnswer()](./search-ui-react.directanswer.md)<!-- -->. |
 |  [FilterGroupCssClasses](./search-ui-react.filtergroupcssclasses.md) | The CSS class interface for FilterGroup. |
 |  [FilterGroupProps](./search-ui-react.filtergroupprops.md) | Props for the FilterGroup component. |
-|  [FilterOptionConfig](./search-ui-react.filteroptionconfig.md) | The configuration data for a filter option. |
+|  [FilterOptionConfig](./search-ui-react.filteroptionconfig.md) | The configuration data for a field value filter option. |
 |  [FilterSearchCssClasses](./search-ui-react.filtersearchcssclasses.md) | The CSS class interface for [FilterSearch()](./search-ui-react.filtersearch.md)<!-- -->. |
 |  [FilterSearchProps](./search-ui-react.filtersearchprops.md) | The props for the [FilterSearch()](./search-ui-react.filtersearch.md) component. |
 |  [HierarchicalFacetDisplayCssClasses](./search-ui-react.hierarchicalfacetdisplaycssclasses.md) | The CSS class interface for HierarchicalFacetDisplay. |
@@ -122,6 +122,6 @@
 |  [onSearchFunc](./search-ui-react.onsearchfunc.md) | The interface of a function which is called on a search. |
 |  [RenderEntityPreviews](./search-ui-react.renderentitypreviews.md) | The type of a functional React component which renders entity previews using a map of vertical key to the corresponding VerticalResults data. |
 |  [SectionComponent](./search-ui-react.sectioncomponent.md) | A component that can be used to render a section template for vertical results. |
-|  [StaticFilterOptionConfig](./search-ui-react.staticfilteroptionconfig.md) | The configuration data for a static filter option. |
+|  [StaticFilterOptionConfig](./search-ui-react.staticfilteroptionconfig.md) | The configuration data for a field value static filter option. |
 |  [VerticalConfigMap](./search-ui-react.verticalconfigmap.md) | A map of verticalKey to a VerticalConfig. |
 

--- a/docs/search-ui-react.staticfilteroptionconfig.md
+++ b/docs/search-ui-react.staticfilteroptionconfig.md
@@ -4,7 +4,7 @@
 
 ## StaticFilterOptionConfig type
 
-The configuration data for a static filter option.
+The configuration data for a field value static filter option.
 
 <b>Signature:</b>
 

--- a/docs/search-ui-react.staticfilters.md
+++ b/docs/search-ui-react.staticfilters.md
@@ -4,7 +4,7 @@
 
 ## StaticFilters() function
 
-A component that displays a group of user-configured filters that will be applied to the current vertical search.
+A component that displays a group of user-configured field value filters that will be applied to the current vertical search.
 
 <b>Signature:</b>
 
@@ -22,5 +22,5 @@ export declare function StaticFilters(props: StaticFiltersProps): JSX.Element;
 
 JSX.Element
 
-A React component for static filters
+A React component for field value static filters
 

--- a/docs/search-ui-react.staticfiltersprops.filteroptions.md
+++ b/docs/search-ui-react.staticfiltersprops.filteroptions.md
@@ -4,7 +4,7 @@
 
 ## StaticFiltersProps.filterOptions property
 
-The configuration data for a static filter option.
+The configuration data for a field value static filter option.
 
 <b>Signature:</b>
 

--- a/docs/search-ui-react.staticfiltersprops.md
+++ b/docs/search-ui-react.staticfiltersprops.md
@@ -20,7 +20,7 @@ export interface StaticFiltersProps
 |  [customCssClasses?](./search-ui-react.staticfiltersprops.customcssclasses.md) | [StaticFiltersCssClasses](./search-ui-react.staticfilterscssclasses.md) | <i>(Optional)</i> CSS classes for customizing the component styling. |
 |  [defaultExpanded?](./search-ui-react.staticfiltersprops.defaultexpanded.md) | boolean | <i>(Optional)</i> If the filter group is collapsible, whether or not it should start out expanded. Defaults to true. |
 |  [fieldId](./search-ui-react.staticfiltersprops.fieldid.md) | string | The fieldId corresponding to the static filter group. |
-|  [filterOptions](./search-ui-react.staticfiltersprops.filteroptions.md) | [StaticFilterOptionConfig](./search-ui-react.staticfilteroptionconfig.md)<!-- -->\[\] | The configuration data for a static filter option. |
+|  [filterOptions](./search-ui-react.staticfiltersprops.filteroptions.md) | [StaticFilterOptionConfig](./search-ui-react.staticfilteroptionconfig.md)<!-- -->\[\] | The configuration data for a field value static filter option. |
 |  [searchable?](./search-ui-react.staticfiltersprops.searchable.md) | boolean | <i>(Optional)</i> Whether or not to display a text input to search for filter options. |
 |  [searchOnChange?](./search-ui-react.staticfiltersprops.searchonchange.md) | boolean | <i>(Optional)</i> Whether or not a search is automatically run when a filter is selected. Defaults to true. |
 |  [title](./search-ui-react.staticfiltersprops.title.md) | string | The displayed label for the static filter group. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/eslint-config-slapshot": "^0.5.0",
-        "@yext/search-headless-react": "^1.4.0",
+        "@yext/search-headless-react": "^2.0.0-alpha.151",
         "axe-playwright": "^1.1.11",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",
@@ -69,7 +69,7 @@
         "typescript": "~4.4.3"
       },
       "peerDependencies": {
-        "@yext/search-headless-react": "^1.4.0",
+        "@yext/search-headless-react": "^2.0.0-alpha.151",
         "react": "^16.14 || ^17 || ^18"
       }
     },
@@ -7759,9 +7759,9 @@
       }
     },
     "node_modules/@yext/search-core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-1.9.0.tgz",
-      "integrity": "sha512-HiAF+8D00ZYl3CbC7E6nc4cNWpJgm93WFARHhSzMeN9Ht8XVqdLKkNZN8vCpg2K2jht2IYhCIuJfpW80kDD62w==",
+      "version": "2.0.0-alpha.204",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.0.0-alpha.204.tgz",
+      "integrity": "sha512-ouV1ZmqrEmwLXBDjxB/Jou3LbkPmHDAKvSyD9E5beO1D+GOmc8BDkGiQ6c9STgYoXH3L58X+NMHiGf3yFNFWgw==",
       "dev": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
@@ -7772,24 +7772,24 @@
       }
     },
     "node_modules/@yext/search-headless": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-1.4.0.tgz",
-      "integrity": "sha512-7lEYYw2+rpP3cFn2ecHbEEPYX1fHd6aYe0FBSqXffXpbBTShuDjsfq4fyvehIu8PSdJsWpqA3RedxRC3q5nQWw==",
+      "version": "2.0.0-alpha.130",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.0.0-alpha.130.tgz",
+      "integrity": "sha512-27dxGT4WHNXhhqkD3NKQdw3Qy4NA7rbLWNUGv+kmF80o+WWw1JLmF8hdy9Os5TdRKwioTK9LwaIciyysuQt+dg==",
       "dev": true,
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^1.9.0",
+        "@yext/search-core": "^2.0.0-alpha.204",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@yext/search-headless-react": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-1.4.0.tgz",
-      "integrity": "sha512-nLjZvRevNyhBCj6IwPjl8Gg5yA1Vvl0T05LxMNOn7Z1PD3eeJWeEYP8DfjNF+n8aFFltGNRL5/c5k0UVf9e2Jw==",
+      "version": "2.0.0-alpha.151",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.0.0-alpha.151.tgz",
+      "integrity": "sha512-7Sduh7zX+I9miBbE9DTJqmb4hHdBJqNzh3Cg/KFVSfeYOF48et5OOy73uwttyAWvyf17y4MLKD6/foFE6gYIOA==",
       "dev": true,
       "dependencies": {
-        "@yext/search-headless": "^1.4.0",
+        "@yext/search-headless": "^2.0.0-alpha.130",
         "use-sync-external-store": "^1.1.0"
       },
       "peerDependencies": {
@@ -7797,9 +7797,9 @@
       }
     },
     "node_modules/@yext/search-headless/node_modules/@reduxjs/toolkit": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.3.tgz",
-      "integrity": "sha512-lU/LDIfORmjBbyDLaqFN2JB9YmAT1BElET9y0ZszwhSBa5Ef3t6o5CrHupw5J1iOXwd+o92QfQZ8OJpwXvsssg==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.4.tgz",
+      "integrity": "sha512-IpFq1WI7sCYeLQpDCGvlcQY9wn70UpAM3cOLq78HRnVn1746RI+l3y5xcuOeVOxORaxABJh3cfJMxycD2IwH5w==",
       "dev": true,
       "dependencies": {
         "immer": "^9.0.7",
@@ -32993,9 +32993,9 @@
       }
     },
     "@yext/search-core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-1.9.0.tgz",
-      "integrity": "sha512-HiAF+8D00ZYl3CbC7E6nc4cNWpJgm93WFARHhSzMeN9Ht8XVqdLKkNZN8vCpg2K2jht2IYhCIuJfpW80kDD62w==",
+      "version": "2.0.0-alpha.204",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.0.0-alpha.204.tgz",
+      "integrity": "sha512-ouV1ZmqrEmwLXBDjxB/Jou3LbkPmHDAKvSyD9E5beO1D+GOmc8BDkGiQ6c9STgYoXH3L58X+NMHiGf3yFNFWgw==",
       "dev": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
@@ -33003,21 +33003,21 @@
       }
     },
     "@yext/search-headless": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-1.4.0.tgz",
-      "integrity": "sha512-7lEYYw2+rpP3cFn2ecHbEEPYX1fHd6aYe0FBSqXffXpbBTShuDjsfq4fyvehIu8PSdJsWpqA3RedxRC3q5nQWw==",
+      "version": "2.0.0-alpha.130",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.0.0-alpha.130.tgz",
+      "integrity": "sha512-27dxGT4WHNXhhqkD3NKQdw3Qy4NA7rbLWNUGv+kmF80o+WWw1JLmF8hdy9Os5TdRKwioTK9LwaIciyysuQt+dg==",
       "dev": true,
       "requires": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^1.9.0",
+        "@yext/search-core": "^2.0.0-alpha.204",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       },
       "dependencies": {
         "@reduxjs/toolkit": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.3.tgz",
-          "integrity": "sha512-lU/LDIfORmjBbyDLaqFN2JB9YmAT1BElET9y0ZszwhSBa5Ef3t6o5CrHupw5J1iOXwd+o92QfQZ8OJpwXvsssg==",
+          "version": "1.8.4",
+          "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.4.tgz",
+          "integrity": "sha512-IpFq1WI7sCYeLQpDCGvlcQY9wn70UpAM3cOLq78HRnVn1746RI+l3y5xcuOeVOxORaxABJh3cfJMxycD2IwH5w==",
           "dev": true,
           "requires": {
             "immer": "^9.0.7",
@@ -33029,12 +33029,12 @@
       }
     },
     "@yext/search-headless-react": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-1.4.0.tgz",
-      "integrity": "sha512-nLjZvRevNyhBCj6IwPjl8Gg5yA1Vvl0T05LxMNOn7Z1PD3eeJWeEYP8DfjNF+n8aFFltGNRL5/c5k0UVf9e2Jw==",
+      "version": "2.0.0-alpha.151",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.0.0-alpha.151.tgz",
+      "integrity": "sha512-7Sduh7zX+I9miBbE9DTJqmb4hHdBJqNzh3Cg/KFVSfeYOF48et5OOy73uwttyAWvyf17y4MLKD6/foFE6gYIOA==",
       "dev": true,
       "requires": {
-        "@yext/search-headless": "^1.4.0",
+        "@yext/search-headless": "^2.0.0-alpha.130",
         "use-sync-external-store": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
     "@yext/eslint-config-slapshot": "^0.5.0",
-    "@yext/search-headless-react": "^1.4.0",
+    "@yext/search-headless-react": "^2.0.0-alpha.151",
     "axe-playwright": "^1.1.11",
     "babel-jest": "^27.0.6",
     "babel-loader": "^8.2.3",
@@ -91,7 +91,7 @@
     "typescript": "~4.4.3"
   },
   "peerDependencies": {
-    "@yext/search-headless-react": "^1.4.0",
+    "@yext/search-headless-react": "^2.0.0-alpha.151",
     "react": "^16.14 || ^17 || ^18"
   },
   "jest": {

--- a/src/components/AppliedFilters.tsx
+++ b/src/components/AppliedFilters.tsx
@@ -49,8 +49,8 @@ const DEFUALT_HIDDEN_FIELDS = ['builtin.entityType'];
 
 /**
  * A component that displays a list of filters applied to the current vertical
- * search, which may include any selected options from static filters, facets, and
- * NLP filters.
+ * search, which may include any selected options from facets, NLP filters, and
+ * field value static filters.
  *
  * @public
  *

--- a/src/components/AppliedFiltersDisplay.tsx
+++ b/src/components/AppliedFiltersDisplay.tsx
@@ -1,8 +1,8 @@
 import { CloseIcon } from '../icons/CloseIcon';
 import { AppliedFiltersCssClasses } from './AppliedFilters';
 import { useClearFiltersCallback } from '../hooks/useClearFiltersCallback';
-import { Filter, useSearchActions } from '@yext/search-headless-react';
-import { isDuplicateFilter } from '../utils/filterutils';
+import { FieldValueFilter, useSearchActions } from '@yext/search-headless-react';
+import { isDuplicateFieldValueFilter } from '../utils/filterutils';
 import { executeSearch } from '../utils/search-operations';
 
 /**
@@ -13,7 +13,7 @@ import { executeSearch } from '../utils/search-operations';
 export interface RemovableFilter {
   displayName: string,
   handleRemove: () => void,
-  filter: Filter
+  filter: FieldValueFilter
 }
 
 /**
@@ -88,7 +88,7 @@ interface DedupedRemovableFilter extends RemovableFilter {
 function getDedupedRemovableFilters(filters: RemovableFilter[]) {
   const dedupedFilters: DedupedRemovableFilter[] = [];
   for (const f of filters) {
-    const preexistingDupe = dedupedFilters.find(d => isDuplicateFilter(d.filter, f.filter));
+    const preexistingDupe = dedupedFilters.find(d => isDuplicateFieldValueFilter(d.filter, f.filter));
     if (!preexistingDupe) {
       dedupedFilters.push(f);
     } else {

--- a/src/components/DirectAnswer.tsx
+++ b/src/components/DirectAnswer.tsx
@@ -72,11 +72,11 @@ export function DirectAnswer(props: DirectAnswerProps): JSX.Element | null {
 
   const cssClasses = getCssClassesForAnswerType(composedCssClasses, directAnswerResult.type);
   const title = directAnswerResult.type === DirectAnswerType.FeaturedSnippet
-    ? directAnswerResult.value
+    ? directAnswerResult.value as string // TODO: update with other direct answer changes
     : `${directAnswerResult.entityName} / ${directAnswerResult.fieldName}`;
   const description: ReactNode = directAnswerResult.type === DirectAnswerType.FeaturedSnippet
     ? renderHighlightedValue(directAnswerResult.snippet, { highlighted: cssClasses.highlighted })
-    : directAnswerResult.value;
+    : directAnswerResult.value as string; // TODO: update with other direct answer changes
   const link = directAnswerResult.relatedResult.link;
 
   function getLinkText(directAnswerResult: DirectAnswerData) {

--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -1,9 +1,9 @@
-import { AutocompleteResult, Filter, FilterSearchResponse, SearchParameterField, useSearchActions, useSearchState } from '@yext/search-headless-react';
+import { AutocompleteResult, FieldValueFilter, FilterSearchResponse, SearchParameterField, useSearchActions, useSearchState } from '@yext/search-headless-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useComposedCssClasses } from '../hooks/useComposedCssClasses';
 import { useSynchronizedRequest } from '../hooks/useSynchronizedRequest';
 import { executeSearch } from '../utils';
-import { isDuplicateFilter } from '../utils/filterutils';
+import { getSelectableFieldValueFilters, isDuplicateFieldValueFilter } from '../utils/filterutils';
 import { Dropdown } from './Dropdown/Dropdown';
 import { DropdownInput } from './Dropdown/DropdownInput';
 import { DropdownItem } from './Dropdown/DropdownItem';
@@ -42,7 +42,7 @@ const builtInCssClasses: Readonly<FilterSearchCssClasses> = {
 export interface FilterSearchProps {
   /** An array of fieldApiName and entityType which indicates what to perform the filter search against. */
   searchFields: Omit<SearchParameterField, 'fetchEntities'>[],
-  /** The display label for the component. Defaults to "Filter". */
+  /** The display label for the component. */
   label?: string,
   /**
    * The search input's placeholder text when no text has been entered by the user.
@@ -78,9 +78,13 @@ export function FilterSearch({
     return { ...searchField, fetchEntities: false };
   });
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses);
-  const [currentFilter, setCurrentFilter] = useState<Filter>();
+  const [currentFilter, setCurrentFilter] = useState<FieldValueFilter>();
   const [filterQuery, setFilterQuery] = useState<string>();
-  const filters = useSearchState(state => state.filters.static);
+  const staticFilters = useSearchState(state => state.filters.static);
+  const fieldValueFilters = useMemo(
+    () => getSelectableFieldValueFilters(staticFilters ?? []),
+    [staticFilters]
+  );
 
   const [
     filterSearchResponse,
@@ -95,12 +99,14 @@ export function FilterSearch({
   );
 
   useEffect(() => {
-    if (currentFilter && filters?.find(f => isDuplicateFilter(f, currentFilter) && !f.selected)) {
+    if (currentFilter && fieldValueFilters?.find(f =>
+      isDuplicateFieldValueFilter(f, currentFilter) && !f.selected
+    )) {
       clearFilterSearchResponse();
       setCurrentFilter(undefined);
       setFilterQuery('');
     }
-  }, [clearFilterSearchResponse, currentFilter, filters]);
+  }, [clearFilterSearchResponse, currentFilter, fieldValueFilters]);
 
   const sections = useMemo(() => {
     return filterSearchResponse?.sections.filter(section => section.results.length > 0) ?? [];
@@ -109,14 +115,21 @@ export function FilterSearch({
   const hasResults = sections.flatMap(s => s.results).length > 0;
 
   const handleDropdownEvent = useCallback((value, itemData, select) => {
-    const newFilter = itemData?.filter as Filter;
+    const newFilter = itemData?.filter as FieldValueFilter;
     const newDisplayName = itemData?.displayName as string;
     if (newFilter && newDisplayName) {
       if (select) {
         if (currentFilter) {
-          searchActions.setFilterOption({ ...currentFilter, selected: false });
+          searchActions.setFilterOption({
+            filter: { ...currentFilter, kind: 'fieldValue' },
+            selected: false
+          });
         }
-        searchActions.setFilterOption({ ...newFilter, displayName: newDisplayName, selected: true });
+        searchActions.setFilterOption({
+          filter: { ...newFilter, kind: 'fieldValue' },
+          displayName: newDisplayName,
+          selected: true
+        });
         setCurrentFilter(newFilter);
         setFilterQuery(newDisplayName);
         executeFilterSearch(newDisplayName);

--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -1,4 +1,4 @@
-import { AutocompleteResult, FieldValueFilter, FilterSearchResponse, SearchParameterField, useSearchActions, useSearchState } from '@yext/search-headless-react';
+import { AutocompleteResult, FieldValueStaticFilter, FilterSearchResponse, SearchParameterField, useSearchActions, useSearchState } from '@yext/search-headless-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useComposedCssClasses } from '../hooks/useComposedCssClasses';
 import { useSynchronizedRequest } from '../hooks/useSynchronizedRequest';
@@ -78,7 +78,7 @@ export function FilterSearch({
     return { ...searchField, fetchEntities: false };
   });
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses);
-  const [currentFilter, setCurrentFilter] = useState<FieldValueFilter>();
+  const [currentFilter, setCurrentFilter] = useState<FieldValueStaticFilter>();
   const [filterQuery, setFilterQuery] = useState<string>();
   const staticFilters = useSearchState(state => state.filters.static);
   const fieldValueFilters = useMemo(
@@ -115,20 +115,14 @@ export function FilterSearch({
   const hasResults = sections.flatMap(s => s.results).length > 0;
 
   const handleDropdownEvent = useCallback((value, itemData, select) => {
-    const newFilter = itemData?.filter as FieldValueFilter;
+    const newFilter = itemData?.filter as FieldValueStaticFilter;
     const newDisplayName = itemData?.displayName as string;
     if (newFilter && newDisplayName) {
       if (select) {
         if (currentFilter) {
-          searchActions.setFilterOption({
-            filter: { ...currentFilter, kind: 'fieldValue' },
-            selected: false
-          });
+          searchActions.setFilterOption({ filter: currentFilter, selected: false });
         }
-        searchActions.setFilterOption({
-          filter: { ...newFilter, kind: 'fieldValue' },
-          displayName: newDisplayName,
-          selected: true
+        searchActions.setFilterOption({ filter: newFilter, displayName: newDisplayName, selected: true
         });
         setCurrentFilter(newFilter);
         setFilterQuery(newDisplayName);
@@ -161,7 +155,7 @@ export function FilterSearch({
   const itemDataMatrix = useMemo(() => {
     return sections.map(section => {
       return section.results.map(result => ({
-        filter: result.filter,
+        filter: { ...result.filter, kind: 'fieldValue' },
         displayName: result.value
       }));
     });

--- a/src/components/Filters/CheckboxOption.tsx
+++ b/src/components/Filters/CheckboxOption.tsx
@@ -1,14 +1,14 @@
-import { Filter, Matcher, NumberRangeValue } from '@yext/search-headless-react';
+import { FieldValueFilter, Matcher, NumberRangeValue } from '@yext/search-headless-react';
 import { useCallback, useEffect, useMemo } from 'react';
 import { v4 as uuid } from 'uuid';
 import { useFiltersContext } from './FiltersContext';
 import { useFilterGroupContext } from './FilterGroupContext';
 import { useComposedCssClasses } from '../../hooks/useComposedCssClasses';
-import { findSelectableFilter } from '../../utils/filterutils';
+import { findSelectableFieldValueFilter } from '../../utils/filterutils';
 import classNames from 'classnames';
 
 /**
- * The configuration data for a filter option.
+ * The configuration data for a field value filter option.
  *
  * @public
  */
@@ -26,12 +26,12 @@ export interface FilterOptionConfig {
 }
 
 /**
- * Props for the {@link Filters.CheckboxOption}
+ * Props for the {@link Filters.CheckboxOption}.
  *
  * @public
  */
 export interface CheckboxOptionProps extends FilterOptionConfig {
-  /** CSS classes for customizing the component styling defined by {@link Filters.CheckboxCssClasses} */
+  /** CSS classes for customizing the component styling defined by {@link Filters.CheckboxCssClasses}. */
   customCssClasses?: CheckboxCssClasses
 }
 
@@ -63,7 +63,7 @@ const builtInCssClasses: Readonly<CheckboxCssClasses> = {
 };
 
 /**
- * A checkbox component that represents a single Filter.
+ * A checkbox component that represents a single FieldValueFilter.
  *
  * @public
  *
@@ -97,14 +97,14 @@ export function CheckboxOption(props: CheckboxOptionProps): JSX.Element | null {
     handleClick(evt.target.checked);
   }, [handleClick]);
 
-  const optionFilter: Filter = useMemo(() => {
+  const optionFilter: FieldValueFilter = useMemo(() => {
     return {
       fieldId,
       matcher,
       value
     };
   }, [fieldId, value, matcher]);
-  const existingStoredFilter = findSelectableFilter(optionFilter, filters);
+  const existingStoredFilter = findSelectableFieldValueFilter(optionFilter, filters);
 
   useEffect(() => {
     if (!existingStoredFilter && selectedByDefault) {

--- a/src/components/Filters/FacetsProvider.tsx
+++ b/src/components/Filters/FacetsProvider.tsx
@@ -1,10 +1,10 @@
 import {
   DisplayableFacet,
-  SelectableFilter as DisplayableFilter,
   useSearchActions,
   useSearchState
 } from '@yext/search-headless-react';
 import { ReactNode, useMemo } from 'react';
+import { SelectableFieldValueFilter } from '../../models/SelectableFieldValueFilter';
 
 import { getSelectedNumericalFacetFields, isNumberRangeValue } from '../../utils/filterutils';
 import { clearStaticRangeFilters } from '../../utils/filterutils';
@@ -50,7 +50,7 @@ export function FacetsProvider({
   const searchActions = useSearchActions();
   const facetsInState = useSearchState(state => state.filters.facets);
   const facets = useMemo(() => facetsInState ?? [], [facetsInState]);
-  const filters: DisplayableFilter[] = useMemo(() => {
+  const filters: SelectableFieldValueFilter[] = useMemo(() => {
     return facets.flatMap(f => f.options.map(o => {
       return {
         fieldId: f.fieldId,
@@ -64,7 +64,7 @@ export function FacetsProvider({
 
   const filtersContextInstance: FiltersContextType = useMemo(() => {
     return {
-      selectFilter(filter: DisplayableFilter) {
+      selectFilter(filter: SelectableFieldValueFilter) {
         if (typeof filter.value === 'object' && !isNumberRangeValue(filter.value)) {
           console.error('Facets only support string, number, boolean, and NumberRangeValue. Found the following object value instead:', filter.value);
           return;

--- a/src/components/Filters/FiltersContext.ts
+++ b/src/components/Filters/FiltersContext.ts
@@ -1,5 +1,5 @@
-import { SelectableFilter as DisplayableFilter } from '@yext/search-headless-react';
 import { createContext, useContext } from 'react';
+import { SelectableFieldValueFilter } from '../../models/SelectableFieldValueFilter';
 
 /**
  * FiltersContext is responsible for handling filter selection.
@@ -8,11 +8,11 @@ import { createContext, useContext } from 'react';
  */
 export interface FiltersContextType {
   /** A function called when a filter is selected. */
-  selectFilter: (filter: DisplayableFilter) => void,
+  selectFilter: (filter: SelectableFieldValueFilter) => void,
   /** A function called when filters should be applied. */
   applyFilters: () => void,
-  /** The list of DisplayableFilter provided by the context. */
-  filters: DisplayableFilter[]
+  /** The list of SelectableFieldValueFilters provided by the context. */
+  filters: SelectableFieldValueFilter[]
 }
 
 /**

--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -5,7 +5,6 @@ import { useComposedCssClasses } from '../../hooks/useComposedCssClasses';
 import { clearStaticRangeFilters, findSelectableFieldValueFilter, getSelectableFieldValueFilters, parseNumberRangeInput } from '../../utils/filterutils';
 import { executeSearch } from '../../utils/search-operations';
 import classNames from 'classnames';
-import { NumberRangeFilter } from '../../models/NumberRangeFilter';
 import { useFiltersContext } from './FiltersContext';
 import { InvalidIcon } from '../../icons/InvalidIcon';
 
@@ -108,8 +107,9 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
   );
   const isDisabled = filters.some(filter => filter.selected && filter.fieldId === fieldId);
 
-  const rangeFilter: NumberRangeFilter = useMemo(() => {
+  const rangeFilter = useMemo(() => {
     return {
+      kind: 'fieldValue' as const,
       fieldId,
       matcher: Matcher.Between,
       value: parseNumberRangeInput(minRangeInput, maxRangeInput),
@@ -148,7 +148,7 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
     const displayName = getFilterDisplayName(rangeFilter.value);
     clearStaticRangeFilters(searchActions, new Set([fieldId]));
     searchActions.setFilterOption({
-      filter: { ...rangeFilter, kind: 'fieldValue' },
+      filter: rangeFilter,
       selected: true,
       displayName
     });
@@ -159,7 +159,7 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
   const handleClickClear = useCallback(() => {
     const displayName = getFilterDisplayName(rangeFilter.value);
     searchActions.setFilterOption({
-      filter: { ...rangeFilter, kind: 'fieldValue' },
+      filter: rangeFilter,
       selected: false,
       displayName
     });

--- a/src/components/Filters/RangeInput.tsx
+++ b/src/components/Filters/RangeInput.tsx
@@ -2,7 +2,7 @@ import { Matcher, NumberRangeValue, useSearchActions, useSearchState } from '@ye
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useFilterGroupContext } from './FilterGroupContext';
 import { useComposedCssClasses } from '../../hooks/useComposedCssClasses';
-import { clearStaticRangeFilters, findSelectableFilter, parseNumberRangeInput } from '../../utils/filterutils';
+import { clearStaticRangeFilters, findSelectableFieldValueFilter, getSelectableFieldValueFilters, parseNumberRangeInput } from '../../utils/filterutils';
 import { executeSearch } from '../../utils/search-operations';
 import classNames from 'classnames';
 import { NumberRangeFilter } from '../../models/NumberRangeFilter';
@@ -102,6 +102,10 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
   const [minRangeInput, setMinRangeInput] = useState<string>('');
   const [maxRangeInput, setMaxRangeInput] = useState<string>('');
   const staticFilters = useSearchState(state => state.filters.static);
+  const fieldValueFilters = useMemo(
+    () => getSelectableFieldValueFilters(staticFilters ?? []),
+    [staticFilters]
+  );
   const isDisabled = filters.some(filter => filter.selected && filter.fieldId === fieldId);
 
   const rangeFilter: NumberRangeFilter = useMemo(() => {
@@ -115,7 +119,7 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
   const isValid = isValidRange(rangeFilter.value);
 
    // Find a static filter which matches the current range input
-  const matchingFilter = findSelectableFilter(rangeFilter, staticFilters ?? []);
+  const matchingFilter = findSelectableFieldValueFilter(rangeFilter, fieldValueFilters);
   const isSelectedInAnswersState = matchingFilter?.selected === true;
   const hasUserInput = !!(minRangeInput || maxRangeInput);
   const shouldRenderApplyButton = hasUserInput && !isSelectedInAnswersState;
@@ -144,7 +148,7 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
     const displayName = getFilterDisplayName(rangeFilter.value);
     clearStaticRangeFilters(searchActions, new Set([fieldId]));
     searchActions.setFilterOption({
-      ...rangeFilter,
+      filter: { ...rangeFilter, kind: 'fieldValue' },
       selected: true,
       displayName
     });
@@ -155,7 +159,7 @@ export function RangeInput(props: RangeInputProps): JSX.Element | null {
   const handleClickClear = useCallback(() => {
     const displayName = getFilterDisplayName(rangeFilter.value);
     searchActions.setFilterOption({
-      ...rangeFilter,
+      filter: { ...rangeFilter, kind: 'fieldValue' },
       selected: false,
       displayName
     });

--- a/src/components/Filters/StaticFiltersProvider.tsx
+++ b/src/components/Filters/StaticFiltersProvider.tsx
@@ -1,5 +1,7 @@
-import { useSearchActions, useSearchState, SelectableFilter as DisplayableFilter } from '@yext/search-headless-react';
+import { useSearchActions, useSearchState } from '@yext/search-headless-react';
 import { PropsWithChildren, useMemo } from 'react';
+import { SelectableFieldValueFilter } from '../../models/SelectableFieldValueFilter';
+import { getSelectableFieldValueFilters } from '../../utils/filterutils';
 import { executeSearch } from '../../utils/search-operations';
 import { FiltersContext, FiltersContextType } from './FiltersContext';
 
@@ -36,8 +38,16 @@ export function StaticFiltersProvider({
 
   const filtersContextInstance: FiltersContextType = useMemo(() => {
     return {
-      selectFilter(filter: DisplayableFilter) {
-        searchActions.setFilterOption({ ...filter });
+      selectFilter(filter: SelectableFieldValueFilter) {
+        const { selected, displayName, ...fieldValueFilter } = filter;
+        searchActions.setFilterOption({
+          filter: {
+            kind: 'fieldValue',
+            ...fieldValueFilter
+          },
+          selected,
+          displayName
+        });
       },
       applyFilters() {
         if (searchOnChange) {
@@ -46,7 +56,7 @@ export function StaticFiltersProvider({
           executeSearch(searchActions);
         }
       },
-      filters: displayableFilters ?? []
+      filters: getSelectableFieldValueFilters(displayableFilters ?? [])
     };
   }, [searchActions, displayableFilters, searchOnChange]);
 

--- a/src/components/StaticFilters.tsx
+++ b/src/components/StaticFilters.tsx
@@ -12,7 +12,7 @@ export interface StaticFiltersCssClasses extends FilterGroupCssClasses {
 }
 
 /**
- * The configuration data for a static filter option.
+ * The configuration data for a field value static filter option.
  *
  * @public
  */
@@ -49,11 +49,11 @@ export interface StaticFiltersProps {
 }
 
 /**
- * A component that displays a group of user-configured filters that will be
- * applied to the current vertical search.
+ * A component that displays a group of user-configured field value filters
+ * that will be applied to the current vertical search.
  *
  * @param props - {@link StaticFiltersProps}
- * @returns A React component for static filters
+ * @returns A React component for field value static filters
  *
  * @public
  */

--- a/src/hooks/useNlpFilterDisplayNames.ts
+++ b/src/hooks/useNlpFilterDisplayNames.ts
@@ -1,6 +1,6 @@
-import { Filter, useSearchState } from '@yext/search-headless-react';
+import { FieldValueFilter, useSearchState } from '@yext/search-headless-react';
 import { useMemo } from 'react';
-import { isDuplicateFilter } from '../utils/filterutils';
+import { isDuplicateFieldValueFilter } from '../utils/filterutils';
 
 /**
  * Returns a memoized array of nlp filter display values, with hiddenFields and duplicate filters removed.
@@ -8,7 +8,7 @@ import { isDuplicateFilter } from '../utils/filterutils';
  * @internal
  */
 export function useNlpFilterDisplayNames(
-  removableFilters: Filter[],
+  removableFilters: FieldValueFilter[],
   hiddenFields: string[]
 ) {
   const nlpFilters = useSearchState(state => state.vertical.appliedQueryFilters);
@@ -18,7 +18,7 @@ export function useNlpFilterDisplayNames(
       if (hiddenFields.includes(filter.fieldId)) {
         return false;
       }
-      const duplicateFilter = removableFilters.find(f => isDuplicateFilter(f, filter));
+      const duplicateFilter = removableFilters.find(f => isDuplicateFieldValueFilter(f, filter));
       return !duplicateFilter;
     }).map(f => f.displayValue) ?? [];
   }, [hiddenFields, nlpFilters, removableFilters]);

--- a/src/hooks/useRemovableFilters.ts
+++ b/src/hooks/useRemovableFilters.ts
@@ -1,4 +1,4 @@
-import { Filter, useSearchState, useSearchActions, DisplayableFacet, DisplayableFacetOption, SearchActions, Matcher } from '@yext/search-headless-react';
+import { FieldValueFilter, useSearchState, useSearchActions, DisplayableFacet, DisplayableFacetOption, SearchActions, Matcher } from '@yext/search-headless-react';
 import { isEqual } from 'lodash';
 import { useMemo } from 'react';
 import { isNearFilterValue } from '../utils/filterutils';
@@ -54,7 +54,7 @@ export function useRemovableFilters(
 function processRegularFacet(f: DisplayableFacet, searchActions: SearchActions) {
   return f.options.filter(o => o.selected).map(option => {
 
-    const filter: Filter = {
+    const filter: FieldValueFilter = {
       value: option.value,
       matcher: option.matcher,
       fieldId: f.fieldId
@@ -97,7 +97,7 @@ function processHierarchicalFacet(
     const appliedFacets: {
       displayName: string,
       handleRemove: () => void,
-      filter: Filter,
+      filter: FieldValueFilter,
       tokens: string[]
     }[] = [createAppliedFilter(selectedOption, displayNameTokens)];
 
@@ -166,9 +166,12 @@ function handleRemoveHierarchicalFacetOption(
   }, true);
 }
 
-function handleRemoveFacetOption({ fieldId, matcher, value }: Filter, searchActions: SearchActions) {
+function handleRemoveFacetOption(
+  { fieldId, matcher, value }: FieldValueFilter,
+  searchActions: SearchActions
+) {
   if (isNearFilterValue(value)) {
-    console.error('A Filter with a NearFilterValue is not a supported RemovableFilter.');
+    console.error('A FieldValueFilter with a NearFilterValue is not a supported RemovableFilter.');
     return;
   }
   searchActions.setFacetOption(fieldId, { matcher, value }, false);

--- a/src/hooks/useRemovableStaticFilters.ts
+++ b/src/hooks/useRemovableStaticFilters.ts
@@ -1,6 +1,8 @@
-import { useSearchState, useSearchActions, SelectableFilter } from '@yext/search-headless-react';
+import { useSearchState, useSearchActions } from '@yext/search-headless-react';
 import { useMemo } from 'react';
 import { RemovableFilter } from '../components/AppliedFiltersDisplay';
+import { SelectableFieldValueFilter } from '../models/SelectableFieldValueFilter';
+import { getSelectableFieldValueFilters } from '../utils/filterutils';
 import { useStateUpdatedOnSearch } from './useStateUpdatedOnSearch';
 
 /**
@@ -18,11 +20,14 @@ export function useRemovableStaticFilters(hiddenFields: string[]): RemovableFilt
       return [];
     }
 
-    function handleRemoveStaticFilterOption(filter: SelectableFilter) {
-      searchActions.setFilterOption({ ...filter, selected: false });
+    function handleRemoveStaticFilterOption(filter: SelectableFieldValueFilter) {
+      searchActions.setFilterOption({
+        filter: { ...filter, kind: 'fieldValue' },
+        selected: false
+      });
     }
 
-    return staticFilters
+    return getSelectableFieldValueFilters(staticFilters)
       .filter(f => f.selected && !hiddenFields.includes(f.fieldId))
       .map(f => ({
         displayName: f.displayName ?? '',

--- a/src/models/NumberRangeFilter.ts
+++ b/src/models/NumberRangeFilter.ts
@@ -1,7 +1,7 @@
-import { Filter, Matcher, NumberRangeValue } from '@yext/search-headless-react';
+import { FieldValueFilter, Matcher, NumberRangeValue } from '@yext/search-headless-react';
 import { isNumberRangeValue } from '../utils/filterutils';
 
-export interface NumberRangeFilter extends Filter {
+export interface NumberRangeFilter extends FieldValueFilter {
   value: NumberRangeValue,
   matcher: Matcher.Between
 }

--- a/src/models/SelectableFieldValueFilter.ts
+++ b/src/models/SelectableFieldValueFilter.ts
@@ -1,0 +1,6 @@
+import { FieldValueFilter } from '@yext/search-headless-react';
+
+export interface SelectableFieldValueFilter extends FieldValueFilter {
+  selected: boolean,
+  displayName?: string
+}

--- a/src/utils/filterutils.tsx
+++ b/src/utils/filterutils.tsx
@@ -135,14 +135,14 @@ export function getSelectedNumericalFacetFields(searchActions: SearchActions): S
 export function getSelectableFieldValueFilters(
   staticFilters: SelectableStaticFilter[]
 ): SelectableFieldValueFilter[] {
-  return staticFilters.reduce((fieldValueFilters: SelectableFieldValueFilter[], s) => {
-    if (s.filter.kind === 'fieldValue') {
-      const { filter: { kind: _, ...filterFields }, ...displayFields } = s;
-      fieldValueFilters.push({
+  return staticFilters.map(s => {
+    const { filter: { kind, ...filterFields }, ...displayFields } = s;
+    if (kind === 'fieldValue') {
+      return {
         ...displayFields,
         ...filterFields
-      });
+      };
     }
-    return fieldValueFilters;
-  }, []);
+    return undefined;
+  }).filter((s): s is SelectableFieldValueFilter => !!s);
 }

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -72,7 +72,7 @@
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/eslint-config-slapshot": "^0.5.0",
-        "@yext/search-headless-react": "^1.4.0",
+        "@yext/search-headless-react": "^2.0.0-alpha.151",
         "axe-playwright": "^1.1.11",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",
@@ -90,7 +90,7 @@
         "typescript": "~4.4.3"
       },
       "peerDependencies": {
-        "@yext/search-headless-react": "^1.4.0",
+        "@yext/search-headless-react": "^2.0.0-alpha.151",
         "react": "^16.14 || ^17 || ^18"
       }
     },
@@ -35317,7 +35317,7 @@
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/analytics": "^0.2.0-beta.3",
         "@yext/eslint-config-slapshot": "^0.5.0",
-        "@yext/search-headless-react": "^1.4.0",
+        "@yext/search-headless-react": "^2.0.0-alpha.151",
         "axe-playwright": "^1.1.11",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",

--- a/tests/__fixtures__/data/filters.ts
+++ b/tests/__fixtures__/data/filters.ts
@@ -1,4 +1,4 @@
-import { DisplayableFacet, Matcher, SelectableFilter as DisplayableFilter } from '@yext/search-headless-react';
+import { DisplayableFacet, Matcher, SelectableStaticFilter } from '@yext/search-headless-react';
 import { RemovableFilter } from '../../../src/components/AppliedFiltersDisplay';
 
 function createRemovableFilter(value: string) {
@@ -74,19 +74,25 @@ export const DisplayableFacets: DisplayableFacet[] = [
   }
 ];
 
-export const staticFilters: DisplayableFilter[] = [
+export const staticFilters: SelectableStaticFilter[] = [
   {
-    fieldId: 'c_puppyPreference',
-    value: 'Bleecker',
+    filter: {
+      kind: 'fieldValue',
+      fieldId: 'c_puppyPreference',
+      value: 'Bleecker',
+      matcher: Matcher.Equals,
+    },
     displayName: 'Bleecker',
-    matcher: Matcher.Equals,
     selected: true
   },
   {
-    fieldId: 'c_puppyPreference',
-    value: 'Clifford',
+    filter: {
+      kind: 'fieldValue',
+      fieldId: 'c_puppyPreference',
+      value: 'Clifford',
+      matcher: Matcher.Equals
+    },
     displayName: 'Clifford',
-    matcher: Matcher.Equals,
     selected: false
   }
 ];

--- a/tests/components/AppliedFilters.test.tsx
+++ b/tests/components/AppliedFilters.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Matcher, Source, State, FiltersState, SelectableStaticFilter, FieldValueStaticFilter } from '@yext/search-headless-react';
+import { Matcher, Source, State, FiltersState, SelectableStaticFilter } from '@yext/search-headless-react';
 import { AppliedFilters } from '../../src/components/AppliedFilters';
 import { getSelectableFieldValueFilters } from '../../src/utils/filterutils';
 import { createHierarchicalFacet } from '../__utils__/hierarchicalfacets';

--- a/tests/components/AppliedFilters.test.tsx
+++ b/tests/components/AppliedFilters.test.tsx
@@ -1,27 +1,36 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Matcher, Source, State, FiltersState } from '@yext/search-headless-react';
+import { Matcher, Source, State, FiltersState, SelectableStaticFilter, FieldValueStaticFilter } from '@yext/search-headless-react';
 import { AppliedFilters } from '../../src/components/AppliedFilters';
 import { createHierarchicalFacet } from '../__utils__/hierarchicalfacets';
 import { spyOnActions, mockAnswersState, mockAnswersHooks } from '../__utils__/mocks';
 
-const mockedStaticFilters = [{
+const mockedStaticFilters: SelectableStaticFilter[] = [{
+  filter: {
+    kind: 'fieldValue',
+    fieldId: 'name',
+    matcher: Matcher.Equals,
+    value: 'Yext Answers'
+  },
   selected: true,
-  fieldId: 'name',
-  matcher: Matcher.Equals,
-  value: 'Yext Answers',
   displayName: 'Yext Answers'
 }, {
+  filter: {
+    kind: 'fieldValue',
+    fieldId: 'name',
+    matcher: Matcher.Equals,
+    value: 'Yext Sites'
+  },
   selected: true,
-  fieldId: 'name',
-  matcher: Matcher.Equals,
-  value: 'Yext Sites',
   displayName: 'Yext Sites'
 }, {
+  filter: {
+    kind: 'fieldValue',
+    fieldId: 'builtin.entityType',
+    matcher: Matcher.Equals,
+    value: 'Yext Pagebuilder'
+  },
   selected: true,
-  fieldId: 'builtin.entityType',
-  matcher: Matcher.Equals,
-  value: 'Yext Pagebuilder',
   displayName: 'Yext Pagebuilder'
 }];
 
@@ -84,7 +93,8 @@ describe('AppliedFilters', () => {
 
   it('Static filters are rendered', () => {
     render(<AppliedFilters />);
-    const staticFilterDisplayName = mockedState.filters.static[0].value as string;
+    const staticFilter = mockedState.filters.static[0].filter as FieldValueStaticFilter;
+    const staticFilterDisplayName = staticFilter.value as string;
     expect(screen.getByText(staticFilterDisplayName)).toBeDefined();
   });
 
@@ -102,13 +112,15 @@ describe('AppliedFilters', () => {
 
   it('Filters with the fieldId of "builtin.entityType" are hidden by default', () => {
     render(<AppliedFilters />);
-    const staticFilterDisplayName = mockedState.filters.static[2].value as string;
+    const staticFilter = mockedState.filters.static[2].filter as FieldValueStaticFilter;
+    const staticFilterDisplayName = staticFilter.value as string;
     expect(screen.queryByText(staticFilterDisplayName)).toBeFalsy();
   });
 
   it('The hiddenFields prop prevents filters with a corresponding fieldId from rendering', () => {
     render(<AppliedFilters hiddenFields={['name']} />);
-    const staticFilterDisplayName = mockedState.filters.static[0].value as string;
+    const staticFilter = mockedState.filters.static[0].filter as FieldValueStaticFilter;
+    const staticFilterDisplayName = staticFilter.value as string;
     expect(screen.queryByText(staticFilterDisplayName)).toBeFalsy();
   });
 

--- a/tests/components/AppliedFilters.test.tsx
+++ b/tests/components/AppliedFilters.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Matcher, Source, State, FiltersState, SelectableStaticFilter, FieldValueStaticFilter } from '@yext/search-headless-react';
 import { AppliedFilters } from '../../src/components/AppliedFilters';
+import { getSelectableFieldValueFilters } from '../../src/utils/filterutils';
 import { createHierarchicalFacet } from '../__utils__/hierarchicalfacets';
 import { spyOnActions, mockAnswersState, mockAnswersHooks } from '../__utils__/mocks';
 
@@ -91,10 +92,11 @@ describe('AppliedFilters', () => {
     mockAnswersHooks({ mockedState, mockedActions });
   });
 
+  const fieldValueFilters = getSelectableFieldValueFilters(mockedState.filters?.static ?? []);
+
   it('Static filters are rendered', () => {
     render(<AppliedFilters />);
-    const staticFilter = mockedState.filters.static[0].filter as FieldValueStaticFilter;
-    const staticFilterDisplayName = staticFilter.value as string;
+    const staticFilterDisplayName = fieldValueFilters[0].value as string;
     expect(screen.getByText(staticFilterDisplayName)).toBeDefined();
   });
 
@@ -112,15 +114,13 @@ describe('AppliedFilters', () => {
 
   it('Filters with the fieldId of "builtin.entityType" are hidden by default', () => {
     render(<AppliedFilters />);
-    const staticFilter = mockedState.filters.static[2].filter as FieldValueStaticFilter;
-    const staticFilterDisplayName = staticFilter.value as string;
+    const staticFilterDisplayName = fieldValueFilters[2].value as string;
     expect(screen.queryByText(staticFilterDisplayName)).toBeFalsy();
   });
 
   it('The hiddenFields prop prevents filters with a corresponding fieldId from rendering', () => {
     render(<AppliedFilters hiddenFields={['name']} />);
-    const staticFilter = mockedState.filters.static[0].filter as FieldValueStaticFilter;
-    const staticFilterDisplayName = staticFilter.value as string;
+    const staticFilterDisplayName = fieldValueFilters[0].value as string;
     expect(screen.queryByText(staticFilterDisplayName)).toBeFalsy();
   });
 

--- a/tests/components/FilterSearch.test.tsx
+++ b/tests/components/FilterSearch.test.tsx
@@ -7,7 +7,7 @@ import {
   unlabeledFilterSearchResponse,
   noResultsFilterSearchResponse
 } from '../../tests/__fixtures__/data/filtersearch';
-import { Matcher, State, SearchHeadless, SearchHeadlessContext, useSearchActions, SelectableFilter } from '@yext/search-headless-react';
+import { Matcher, State, SearchHeadless, SearchHeadlessContext, useSearchActions, SelectableStaticFilter } from '@yext/search-headless-react';
 import { generateMockedHeadless } from '../__fixtures__/search-headless';
 
 const searchFieldsProp = [{
@@ -141,9 +141,12 @@ describe('search with section labels', () => {
     userEvent.type(searchBarElement, '{enter}');
     await waitFor(() => {
       expect(setFilterOption).toBeCalledWith({
-        fieldId: 'name',
-        matcher: Matcher.Equals,
-        value: 'first name 1',
+        filter: {
+          kind: 'fieldValue',
+          fieldId: 'name',
+          matcher: Matcher.Equals,
+          value: 'first name 1'
+        },
         displayName: 'first name 1',
         selected: true
       });
@@ -155,16 +158,22 @@ describe('search with section labels', () => {
     userEvent.type(searchBarElement, '{arrowdown}{enter}');
     await waitFor(() => {
       expect(setFilterOption).toBeCalledWith({
-        fieldId: 'name',
-        matcher: Matcher.Equals,
-        value: 'first name 1',
+        filter: {
+          kind: 'fieldValue',
+          fieldId: 'name',
+          matcher: Matcher.Equals,
+          value: 'first name 1'
+        },
         selected: false
       });
     });
     expect(setFilterOption).toBeCalledWith({
-      fieldId: 'name',
-      matcher: Matcher.Equals,
-      value: 'first name 2',
+      filter: {
+        kind: 'fieldValue',
+        fieldId: 'name',
+        matcher: Matcher.Equals,
+        value: 'first name 2'
+      },
       displayName: 'first name 2',
       selected: true
     });
@@ -187,9 +196,12 @@ describe('search with section labels', () => {
       await waitFor(() => screen.findByText('first name 1'));
 
       const expectedSetFilterOptionParam = {
-        fieldId: 'name',
-        matcher: Matcher.Equals,
-        value: 'first name 1',
+        filter: {
+          kind: 'fieldValue',
+          fieldId: 'name',
+          matcher: Matcher.Equals,
+          value: 'first name 1'
+        },
         displayName: 'first name 1',
         selected: true
       };
@@ -245,9 +257,12 @@ describe('search with section labels', () => {
       const autocompleteSuggestion = await waitFor(() => screen.findByText('first name 1'));
 
       const expectedSetFilterOptionParam = {
-        fieldId: 'name',
-        matcher: Matcher.Equals,
-        value: 'first name 1',
+        filter: {
+          kind: 'fieldValue',
+          fieldId: 'name',
+          matcher: Matcher.Equals,
+          value: 'first name 1'
+        },
         displayName: 'first name 1',
         selected: true
       };
@@ -288,9 +303,12 @@ describe('search with section labels', () => {
         expect(executeFilterSearch).toHaveBeenCalled();
       });
       expect(setFilterOption).toBeCalledWith({
-        fieldId: 'name',
-        matcher: Matcher.Equals,
-        value: 'first name 1',
+        filter: {
+          kind: 'fieldValue',
+          fieldId: 'name',
+          matcher: Matcher.Equals,
+          value: 'first name 1'
+        },
         displayName: 'first name 1',
         selected: true
       });
@@ -403,10 +421,13 @@ it('clears input when old filters are removed', async () => {
     .spyOn(SearchHeadless.prototype, 'executeFilterSearch')
     .mockResolvedValue(labeledFilterSearchResponse);
 
-  const deselectedFilter: SelectableFilter = {
-    fieldId: 'name',
-    matcher: Matcher.Equals,
-    value: 'first name 1',
+  const deselectedFilter: SelectableStaticFilter = {
+    filter: {
+      kind: 'fieldValue',
+      fieldId: 'name',
+      matcher: Matcher.Equals,
+      value: 'first name 1'
+    },
     displayName: 'first name 1',
     selected: false
   };

--- a/tests/components/NumericalFacets.test.tsx
+++ b/tests/components/NumericalFacets.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { SearchActions, FacetOption, Matcher, NumberRangeValue, SelectableFilter, Source, State } from '@yext/search-headless-react';
+import { SearchActions, FacetOption, Matcher, NumberRangeValue, SelectableStaticFilter, Source, State } from '@yext/search-headless-react';
 import { mockAnswersHooks, mockAnswersState, spyOnActions } from '../__utils__/mocks';
 import userEvent from '@testing-library/user-event';
 import { DisplayableFacets } from '../__fixtures__/data/filters';
@@ -106,21 +106,24 @@ describe('NumericalFacets', () => {
     userEvent.type(screen.getByPlaceholderText('Max'), '5');
     userEvent.click(screen.getByText('Apply'));
 
-    const expectedSelectableFilter: SelectableFilter = {
+    const expectedSelectableFilter: SelectableStaticFilter = {
       displayName: 'start-1 end-5',
-      fieldId: 'price',
-      value: {
-        start: {
-          matcher: Matcher.GreaterThanOrEqualTo,
-          value: 1
+      selected: true,
+      filter: {
+        kind: 'fieldValue',
+        fieldId: 'price',
+        value: {
+          start: {
+            matcher: Matcher.GreaterThanOrEqualTo,
+            value: 1
+          },
+          end: {
+            matcher: Matcher.LessThanOrEqualTo,
+            value: 5
+          }
         },
-        end: {
-          matcher: Matcher.LessThanOrEqualTo,
-          value: 5
-        }
-      },
-      matcher: Matcher.Between,
-      selected: true
+        matcher: Matcher.Between
+      }
     };
     expect(actions.setFilterOption).toHaveBeenCalledWith(expectedSelectableFilter);
   });

--- a/tests/components/RangeInput.stories.tsx
+++ b/tests/components/RangeInput.stories.tsx
@@ -1,10 +1,11 @@
 import { ComponentMeta } from '@storybook/react';
 import { RangeInput, RangeInputProps } from '../../src/components/Filters/RangeInput';
-import { SearchHeadlessContext, Matcher, SelectableFilter } from '@yext/search-headless-react';
+import { SearchHeadlessContext, Matcher } from '@yext/search-headless-react';
 import { generateMockedHeadless } from '../__fixtures__/search-headless';
 import { FiltersContext, FiltersContextType } from '../../src/components/Filters/FiltersContext';
 import { FilterGroupContext, FilterGroupContextType } from '../../src/components/Filters/FilterGroupContext';
 import { userEvent, within } from '@storybook/testing-library';
+import { SelectableFieldValueFilter } from '../../src/models/SelectableFieldValueFilter';
 
 const meta: ComponentMeta<typeof RangeInput> = {
   title: 'RangeInput',
@@ -13,7 +14,7 @@ const meta: ComponentMeta<typeof RangeInput> = {
 
 export default meta;
 
-const selectableFilter: SelectableFilter = {
+const selectableFilter: SelectableFieldValueFilter = {
   selected: true,
   fieldId: '123',
   matcher: Matcher.Equals,

--- a/tests/components/RangeInput.test.tsx
+++ b/tests/components/RangeInput.test.tsx
@@ -1,10 +1,11 @@
 import userEvent from '@testing-library/user-event';
-import { State, Matcher, SelectableFilter } from '@yext/search-headless-react';
+import { State, Matcher } from '@yext/search-headless-react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { RangeInput } from '../../src/components/Filters';
 import { mockAnswersHooks, spyOnActions } from '../__utils__/mocks';
 import { FiltersContext, FiltersContextType } from '../../src/components/Filters/FiltersContext';
 import { FilterGroupContext, FilterGroupContextType } from '../../src/components/Filters/FilterGroupContext';
+import { SelectableFieldValueFilter } from '../../src/models/SelectableFieldValueFilter';
 
 const mockedState: Partial<State> = {
   filters: {
@@ -51,14 +52,17 @@ describe('Renders correctly for min input', () => {
     userEvent.click(screen.getByText('Apply'));
     expect(actions.setFilterOption).toHaveBeenCalledWith({
       displayName: 'Over 10',
-      fieldId: '123',
-      matcher: '$between',
       selected: true,
-      value: {
-        start: {
-          matcher: '$ge',
-          value: 10
-        },
+      filter: {
+        kind: 'fieldValue',
+        fieldId: '123',
+        matcher: '$between',
+        value: {
+          start: {
+            matcher: '$ge',
+            value: 10
+          }
+        }
       }
     });
   });
@@ -75,14 +79,17 @@ describe('Renders correctly for min input', () => {
     expect(minTextbox).toHaveValue('');
     expect(actions.setFilterOption).toHaveBeenCalledWith({
       displayName: 'Over 10',
-      fieldId: '123',
-      matcher: '$between',
       selected: false,
-      value: {
-        start: {
-          matcher: '$ge',
-          value: 10
-        },
+      filter: {
+        kind: 'fieldValue',
+        fieldId: '123',
+        matcher: '$between',
+        value: {
+          start: {
+            matcher: '$ge',
+            value: 10
+          }
+        }
       }
     });
   });
@@ -106,14 +113,17 @@ describe('Renders correctly for max input', () => {
     userEvent.click(screen.getByText('Apply'));
     expect(actions.setFilterOption).toHaveBeenCalledWith({
       displayName: 'Up to 20',
-      fieldId: '123',
-      matcher: '$between',
       selected: true,
-      value: {
-        end: {
-          matcher: '$le',
-          value: 20
-        },
+      filter: {
+        kind: 'fieldValue',
+        fieldId: '123',
+        matcher: '$between',
+        value: {
+          end: {
+            matcher: '$le',
+            value: 20
+          }
+        }
       }
     });
   });
@@ -130,14 +140,17 @@ describe('Renders correctly for max input', () => {
     expect(maxTextbox).toHaveValue('');
     expect(actions.setFilterOption).toHaveBeenCalledWith({
       displayName: 'Up to 20',
-      fieldId: '123',
-      matcher: '$between',
       selected: false,
-      value: {
-        end: {
-          matcher: '$le',
-          value: 20
-        },
+      filter: {
+        kind: 'fieldValue',
+        fieldId: '123',
+        matcher: '$between',
+        value: {
+          end: {
+            matcher: '$le',
+            value: 20
+          }
+        }
       }
     });
   });
@@ -163,18 +176,21 @@ describe('Renders correctly for min and max inputs', () => {
     userEvent.click(screen.getByText('Apply'));
     expect(actions.setFilterOption).toHaveBeenCalledWith({
       displayName: '10 - 20',
-      fieldId: '123',
-      matcher: '$between',
       selected: true,
-      value: {
-        start: {
-          matcher: '$ge',
-          value: 10
-        },
-        end: {
-          matcher: '$le',
-          value: 20
-        },
+      filter: {
+        kind: 'fieldValue',
+        fieldId: '123',
+        matcher: '$between',
+        value: {
+          start: {
+            matcher: '$ge',
+            value: 10
+          },
+          end: {
+            matcher: '$le',
+            value: 20
+          }
+        }
       }
     });
   });
@@ -194,18 +210,21 @@ describe('Renders correctly for min and max inputs', () => {
     expect(maxTextbox).toHaveValue('');
     expect(actions.setFilterOption).toHaveBeenCalledWith({
       displayName: '10 - 20',
-      fieldId: '123',
-      matcher: '$between',
       selected: false,
-      value: {
-        start: {
-          matcher: '$ge',
-          value: 10
-        },
-        end: {
-          matcher: '$le',
-          value: 20
-        },
+      filter: {
+        kind: 'fieldValue',
+        fieldId: '123',
+        matcher: '$between',
+        value: {
+          start: {
+            matcher: '$ge',
+            value: 10
+          },
+          end: {
+            matcher: '$le',
+            value: 20
+          }
+        }
       }
     });
   });
@@ -226,7 +245,7 @@ describe('Renders correctly for min and max inputs', () => {
 });
 
 it('renders correctly when disabled', () => {
-  const selectableFilter: SelectableFilter = {
+  const selectableFilter: SelectableFieldValueFilter = {
     selected: true,
     fieldId: '123',
     matcher: Matcher.Between,

--- a/tests/components/StaticFilters.stories.tsx
+++ b/tests/components/StaticFilters.stories.tsx
@@ -4,6 +4,7 @@ import { userEvent, within } from '@storybook/testing-library';
 import { generateMockedHeadless } from '../__fixtures__/search-headless';
 import { staticFilters } from '../__fixtures__/data/filters';
 import { StaticFilters, StaticFiltersProps } from '../../src';
+import { getSelectableFieldValueFilters } from '../../src/utils/filterutils';
 
 const meta: ComponentMeta<typeof StaticFilters> = {
   title: 'StaticFilters',
@@ -15,9 +16,9 @@ export const Primary = (args: StaticFiltersProps) => {
   return (
     <SearchHeadlessContext.Provider value={generateMockedHeadless()}>
       <StaticFilters
-        fieldId={staticFilters[0].fieldId}
+        fieldId={staticFilters[0].filter.fieldId}
         title='Puppy Preference'
-        filterOptions={staticFilters}
+        filterOptions={getSelectableFieldValueFilters(staticFilters)}
         {...args}
       />
     </SearchHeadlessContext.Provider>
@@ -33,9 +34,9 @@ export const Searchable = (args: StaticFiltersProps) => {
   return (
     <SearchHeadlessContext.Provider value={generateMockedHeadless()}>
       <StaticFilters
-        fieldId={staticFilters[0].fieldId}
+        fieldId={staticFilters[0].filter.fieldId}
         title='Puppy Preference'
-        filterOptions={staticFilters}
+        filterOptions={getSelectableFieldValueFilters(staticFilters)}
         searchable={true}
         {...args}
       />

--- a/tests/components/StaticFilters.test.tsx
+++ b/tests/components/StaticFilters.test.tsx
@@ -178,10 +178,13 @@ function expectFilterOptionSet(
   filterOption: FilterOptionConfig,
   selected: boolean
 ) {
-  expect(actions.setFilterOption).toHaveBeenCalledWith({
-    fieldId,
-    matcher: '$eq',
-    value: filterOption.value,
+  expect(actions.setFilterOption).toHaveBeenLastCalledWith({
+    filter: {
+      kind: 'fieldValue',
+      fieldId,
+      matcher: '$eq',
+      value: filterOption.value
+    },
     displayName: filterOption.displayName ?? filterOption.value,
     selected
   });


### PR DESCRIPTION
Update the components that interact with the static filters State to work with the changes in Headless. The `StaticFilters` and `AppliedFilters` components will only work with field value filters. If someone wants to create and display more complex static filters, they should fork the components and do that themselves.

Also, because the Headless-React alpha versions include the change in Core to make direct answers generic, I updated the component to manually cast those values as strings for now. That behavior should be changed with the other direct answer work.

J=SLAP-2327
TEST=manual

Spin up the test-site and see that static filters, range input filters, and filter search filters can be successfully applied and removed.