### PR TITLE
FieldValueDirectAnswer component

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -758,7 +758,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-core@2.0.0-alpha.204
+ - @yext/search-core@2.0.0-alpha.218
 
 This package contains the following license and notice below:
 
@@ -802,7 +802,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless-react@2.0.0-alpha.151
+ - @yext/search-headless-react@2.0.0-alpha.152
 
 This package contains the following license and notice below:
 
@@ -846,7 +846,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless@2.0.0-alpha.130
+ - @yext/search-headless@2.0.0-alpha.134
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/eslint-config-slapshot": "^0.5.0",
-        "@yext/search-headless-react": "^2.0.0-alpha.151",
+        "@yext/search-headless-react": "^2.0.0-alpha.152",
         "axe-playwright": "^1.1.11",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",
@@ -69,7 +69,7 @@
         "typescript": "~4.4.3"
       },
       "peerDependencies": {
-        "@yext/search-headless-react": "^2.0.0-alpha.151",
+        "@yext/search-headless-react": "^2.0.0-alpha.152",
         "react": "^16.14 || ^17 || ^18"
       }
     },
@@ -7759,9 +7759,9 @@
       }
     },
     "node_modules/@yext/search-core": {
-      "version": "2.0.0-alpha.204",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.0.0-alpha.204.tgz",
-      "integrity": "sha512-ouV1ZmqrEmwLXBDjxB/Jou3LbkPmHDAKvSyD9E5beO1D+GOmc8BDkGiQ6c9STgYoXH3L58X+NMHiGf3yFNFWgw==",
+      "version": "2.0.0-alpha.218",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.0.0-alpha.218.tgz",
+      "integrity": "sha512-G53E3tUjYzGrLzBeAnXwaovGl682QyKGzDveB+QfzZMpfOspdukxRFVmoEfePii86aNNbBLOF8vJZ/J/cwzCjg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
@@ -7772,24 +7772,24 @@
       }
     },
     "node_modules/@yext/search-headless": {
-      "version": "2.0.0-alpha.130",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.0.0-alpha.130.tgz",
-      "integrity": "sha512-27dxGT4WHNXhhqkD3NKQdw3Qy4NA7rbLWNUGv+kmF80o+WWw1JLmF8hdy9Os5TdRKwioTK9LwaIciyysuQt+dg==",
+      "version": "2.0.0-alpha.134",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.0.0-alpha.134.tgz",
+      "integrity": "sha512-QRt8gsbrSteOYubYpXS88Sf7pOLxI1s/vK3ngOOYTlbL/w3BA3ScDbhTuS8hcKnWByl9I1FgcRxWMuB3ePI7dg==",
       "dev": true,
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^2.0.0-alpha.204",
+        "@yext/search-core": "2.0.0-alpha.218",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@yext/search-headless-react": {
-      "version": "2.0.0-alpha.151",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.0.0-alpha.151.tgz",
-      "integrity": "sha512-7Sduh7zX+I9miBbE9DTJqmb4hHdBJqNzh3Cg/KFVSfeYOF48et5OOy73uwttyAWvyf17y4MLKD6/foFE6gYIOA==",
+      "version": "2.0.0-alpha.152",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.0.0-alpha.152.tgz",
+      "integrity": "sha512-OKYNCtQLGMed8RpaZWknF/v4EuWbgRQQrljk+mtQNHcw0glrnaQPYP5qHyrlm36LgS6oQaE3KVUCxQDErtsvYQ==",
       "dev": true,
       "dependencies": {
-        "@yext/search-headless": "^2.0.0-alpha.130",
+        "@yext/search-headless": "^2.0.0-alpha.133",
         "use-sync-external-store": "^1.1.0"
       },
       "peerDependencies": {
@@ -32993,9 +32993,9 @@
       }
     },
     "@yext/search-core": {
-      "version": "2.0.0-alpha.204",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.0.0-alpha.204.tgz",
-      "integrity": "sha512-ouV1ZmqrEmwLXBDjxB/Jou3LbkPmHDAKvSyD9E5beO1D+GOmc8BDkGiQ6c9STgYoXH3L58X+NMHiGf3yFNFWgw==",
+      "version": "2.0.0-alpha.218",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.0.0-alpha.218.tgz",
+      "integrity": "sha512-G53E3tUjYzGrLzBeAnXwaovGl682QyKGzDveB+QfzZMpfOspdukxRFVmoEfePii86aNNbBLOF8vJZ/J/cwzCjg==",
       "dev": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
@@ -33003,13 +33003,13 @@
       }
     },
     "@yext/search-headless": {
-      "version": "2.0.0-alpha.130",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.0.0-alpha.130.tgz",
-      "integrity": "sha512-27dxGT4WHNXhhqkD3NKQdw3Qy4NA7rbLWNUGv+kmF80o+WWw1JLmF8hdy9Os5TdRKwioTK9LwaIciyysuQt+dg==",
+      "version": "2.0.0-alpha.134",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.0.0-alpha.134.tgz",
+      "integrity": "sha512-QRt8gsbrSteOYubYpXS88Sf7pOLxI1s/vK3ngOOYTlbL/w3BA3ScDbhTuS8hcKnWByl9I1FgcRxWMuB3ePI7dg==",
       "dev": true,
       "requires": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^2.0.0-alpha.204",
+        "@yext/search-core": "2.0.0-alpha.218",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       },
@@ -33029,12 +33029,12 @@
       }
     },
     "@yext/search-headless-react": {
-      "version": "2.0.0-alpha.151",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.0.0-alpha.151.tgz",
-      "integrity": "sha512-7Sduh7zX+I9miBbE9DTJqmb4hHdBJqNzh3Cg/KFVSfeYOF48et5OOy73uwttyAWvyf17y4MLKD6/foFE6gYIOA==",
+      "version": "2.0.0-alpha.152",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.0.0-alpha.152.tgz",
+      "integrity": "sha512-OKYNCtQLGMed8RpaZWknF/v4EuWbgRQQrljk+mtQNHcw0glrnaQPYP5qHyrlm36LgS6oQaE3KVUCxQDErtsvYQ==",
       "dev": true,
       "requires": {
-        "@yext/search-headless": "^2.0.0-alpha.130",
+        "@yext/search-headless": "^2.0.0-alpha.133",
         "use-sync-external-store": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
     "@yext/eslint-config-slapshot": "^0.5.0",
-    "@yext/search-headless-react": "^2.0.0-alpha.151",
+    "@yext/search-headless-react": "^2.0.0-alpha.152",
     "axe-playwright": "^1.1.11",
     "babel-jest": "^27.0.6",
     "babel-loader": "^8.2.3",
@@ -91,7 +91,7 @@
     "typescript": "~4.4.3"
   },
   "peerDependencies": {
-    "@yext/search-headless-react": "^2.0.0-alpha.151",
+    "@yext/search-headless-react": "^2.0.0-alpha.152",
     "react": "^16.14 || ^17 || ^18"
   },
   "jest": {

--- a/src/components/DirectAnswer.tsx
+++ b/src/components/DirectAnswer.tsx
@@ -1,16 +1,18 @@
-import { useSearchState, DirectAnswerType, DirectAnswer as DirectAnswerData } from '@yext/search-headless-react';
-import { renderHighlightedValue } from './utils/renderHighlightedValue';
-import classNames from 'classnames';
-import { ReactNode } from 'react';
-import { useComposedCssClasses } from '../hooks/useComposedCssClasses';
+import {
+  useSearchState,
+  DirectAnswerType,
+  DirectAnswer as DirectAnswerData,
+} from '@yext/search-headless-react';
 import {
   ThumbsFeedbackCssClasses,
   ThumbsFeedback,
   builtInCssClasses as thumbsFeedbackCssClasses
 } from './ThumbsFeedback';
-
+import classNames from 'classnames';
+import { useComposedCssClasses } from '../hooks/useComposedCssClasses';
 import { useCardAnalyticsCallback } from '../hooks/useCardAnalyticsCallback';
 import { useCardFeedbackCallback } from '../hooks/useCardFeedbackCallback';
+import { FieldValueDirectAnswer } from './FieldValueDirectAnswer';
 
 /**
  * Props for {@link DirectAnswer}.
@@ -71,56 +73,20 @@ export function DirectAnswer(props: DirectAnswerProps): JSX.Element | null {
   }
 
   const cssClasses = getCssClassesForAnswerType(composedCssClasses, directAnswerResult.type);
-  const title = directAnswerResult.type === DirectAnswerType.FeaturedSnippet
-    ? directAnswerResult.value as string // TODO: update with other direct answer changes
-    : `${directAnswerResult.entityName} / ${directAnswerResult.fieldName}`;
-  const description: ReactNode = directAnswerResult.type === DirectAnswerType.FeaturedSnippet
-    ? renderHighlightedValue(directAnswerResult.snippet, { highlighted: cssClasses.highlighted })
-    : directAnswerResult.value as string; // TODO: update with other direct answer changes
-  const link = directAnswerResult.relatedResult.link;
-
-  function getLinkText(directAnswerResult: DirectAnswerData) {
-    const isSnippet = directAnswerResult.type === DirectAnswerType.FeaturedSnippet;
-    const name = directAnswerResult.relatedResult.name;
-    const snippetLinkMessage = 'Read more about ';
-
-    return (<>
-      {isSnippet && name && <div className='pt-4 text-neutral'>
-        {snippetLinkMessage}
-        <a
-          className='text-primary'
-          href={link}
-          onClick={handleClickViewDetails}
-        >
-          {name}
-        </a>
-      </div>}
-      {!isSnippet && link && <div className='pt-4 text-neutral'>
-        <a
-          href={link}
-          className='text-primary'
-          onClick={handleClickViewDetails}
-        >
-          View Details
-        </a>
-      </div>}
-    </>);
-  }
-
-  const containerCssClasses = classNames(cssClasses.directAnswerContainer, {
-    [cssClasses.directAnswerLoading ?? '']: isLoading
+  const containerCssClasses = classNames(composedCssClasses.directAnswerContainer, {
+    [composedCssClasses.directAnswerLoading ?? '']: isLoading
   });
 
   return (
     <div className={containerCssClasses}>
-      <div className={cssClasses.answerContainer}>
-        {title &&
-          <div className={cssClasses.header}>{title}</div>}
-        <div className={cssClasses.content}>
-          <div className={cssClasses.body}>{description}</div>
-          {link && getLinkText(directAnswerResult)}
-        </div>
-      </div>
+      {directAnswerResult.type === DirectAnswerType.FieldValue
+        ? <FieldValueDirectAnswer
+          result={directAnswerResult}
+          cssClasses={cssClasses}
+          handleClickViewDetails={handleClickViewDetails}
+        />
+        : <div>Snippet!</div> //TODO: create FeaturedSnippetDirectAnswer component
+      }
       <ThumbsFeedback
         onClick={handleClickFeedbackButton}
         customCssClasses={composedCssClasses}

--- a/src/components/DirectAnswer.tsx
+++ b/src/components/DirectAnswer.tsx
@@ -8,8 +8,7 @@ import {
   ThumbsFeedback,
   builtInCssClasses as thumbsFeedbackCssClasses
 } from './ThumbsFeedback';
-import classNames from 'classnames';
-import { useComposedCssClasses } from '../hooks/useComposedCssClasses';
+import { twMerge, useComposedCssClasses } from '../hooks/useComposedCssClasses';
 import { useCardAnalyticsCallback } from '../hooks/useCardAnalyticsCallback';
 import { useCardFeedbackCallback } from '../hooks/useCardFeedbackCallback';
 import { FieldValueDirectAnswer } from './FieldValueDirectAnswer';
@@ -74,9 +73,10 @@ export function DirectAnswer(props: DirectAnswerProps): JSX.Element | null {
   }
 
   const cssClasses = getCssClassesForAnswerType(composedCssClasses, directAnswerResult.type);
-  const containerCssClasses = classNames(cssClasses.directAnswerContainer, {
-    [cssClasses.directAnswerLoading ?? '']: isLoading
-  });
+  const containerCssClasses = twMerge(
+    cssClasses.directAnswerContainer,
+    isLoading && cssClasses.directAnswerLoading
+  );
 
   const link = directAnswerResult.relatedResult.link;
   function getLinkText(directAnswerResult: DirectAnswerData) {

--- a/src/components/DirectAnswer.tsx
+++ b/src/components/DirectAnswer.tsx
@@ -13,6 +13,7 @@ import { useComposedCssClasses } from '../hooks/useComposedCssClasses';
 import { useCardAnalyticsCallback } from '../hooks/useCardAnalyticsCallback';
 import { useCardFeedbackCallback } from '../hooks/useCardFeedbackCallback';
 import { FieldValueDirectAnswer } from './FieldValueDirectAnswer';
+import { renderHighlightedValue } from './utils/renderHighlightedValue';
 
 /**
  * Props for {@link DirectAnswer}.
@@ -77,6 +78,26 @@ export function DirectAnswer(props: DirectAnswerProps): JSX.Element | null {
     [composedCssClasses.directAnswerLoading ?? '']: isLoading
   });
 
+  const link = directAnswerResult.relatedResult.link;
+  function getLinkText(directAnswerResult: DirectAnswerData) {
+    const isSnippet = directAnswerResult.type === DirectAnswerType.FeaturedSnippet;
+    const name = directAnswerResult.relatedResult.name;
+    const snippetLinkMessage = 'Read more about ';
+
+    return (<>
+      {isSnippet && name && <div className='pt-4 text-neutral'>
+        {snippetLinkMessage}
+        <a
+          className='text-primary'
+          href={link}
+          onClick={handleClickViewDetails}
+        >
+          {name}
+        </a>
+      </div>}
+    </>);
+  }
+
   return (
     <div className={containerCssClasses}>
       {directAnswerResult.type === DirectAnswerType.FieldValue
@@ -85,7 +106,17 @@ export function DirectAnswer(props: DirectAnswerProps): JSX.Element | null {
           cssClasses={cssClasses}
           viewDetailsClickHandler={handleClickViewDetails}
         />
-        : <div>Snippet!</div> //TODO: create FeaturedSnippetDirectAnswer component
+        //TODO: SLAP-2335 create FeaturedSnippetDirectAnswer component
+        : <div className={cssClasses.answerContainer}>
+          {directAnswerResult['value'] &&
+          <div className={cssClasses.header}>{directAnswerResult['value']}</div>}
+          <div className={cssClasses.content}>
+            <div className={cssClasses.body}>
+              {renderHighlightedValue(directAnswerResult.snippet, { highlighted: cssClasses.highlighted })}
+            </div>
+            {link && getLinkText(directAnswerResult)}
+          </div>
+        </div>
       }
       <ThumbsFeedback
         onClick={handleClickFeedbackButton}

--- a/src/components/DirectAnswer.tsx
+++ b/src/components/DirectAnswer.tsx
@@ -74,8 +74,8 @@ export function DirectAnswer(props: DirectAnswerProps): JSX.Element | null {
   }
 
   const cssClasses = getCssClassesForAnswerType(composedCssClasses, directAnswerResult.type);
-  const containerCssClasses = classNames(composedCssClasses.directAnswerContainer, {
-    [composedCssClasses.directAnswerLoading ?? '']: isLoading
+  const containerCssClasses = classNames(cssClasses.directAnswerContainer, {
+    [cssClasses.directAnswerLoading ?? '']: isLoading
   });
 
   const link = directAnswerResult.relatedResult.link;

--- a/src/components/DirectAnswer.tsx
+++ b/src/components/DirectAnswer.tsx
@@ -83,7 +83,7 @@ export function DirectAnswer(props: DirectAnswerProps): JSX.Element | null {
         ? <FieldValueDirectAnswer
           result={directAnswerResult}
           cssClasses={cssClasses}
-          handleClickViewDetails={handleClickViewDetails}
+          viewDetailsClickHandler={handleClickViewDetails}
         />
         : <div>Snippet!</div> //TODO: create FeaturedSnippetDirectAnswer component
       }

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -45,13 +45,12 @@ export function FieldValueDirectAnswer({
       <div className={cssClasses.header}>{title}</div>}
       <div className={cssClasses.content}>
         <div className={cssClasses.body}>{description}</div>
-        {link && <a
-          href={link}
-          className='text-primary pt-4 text-neutral'
-          onClick={viewDetailsClickHandler}
-        >
-          View Details
-        </a>}
+        {link && <div className='mt-4'>
+          <a href={link} className='text-primary' onClick={viewDetailsClickHandler}>
+            View Details
+          </a>
+        </div>
+        }
       </div>
     </div>
   );
@@ -73,12 +72,12 @@ function getResultContent(result: FieldValueDirectAnswerType): JSX.Element {
       return getUrlJsxElement(url, displayUrl);
     case BuiltInFieldType.URL:
       return Array.isArray(result.value)
-        ? <div>{result.value.map((url, i) => getUrlJsxElement(url, url, i))}</div>
+        ? getListJsxElement(result.value, url => getUrlJsxElement(url))
         : getUrlJsxElement(result.value);
     case BuiltInFieldType.Phone:
       return getUrlJsxElement(`tel:${result.value}`, result.value);
     case BuiltInFieldType.Email:
-      return <div>{result.value.map((e, i) => getUrlJsxElement(`mailto:${e}`, e, i))}</div>;
+      return getListJsxElement(result.value, e => getUrlJsxElement(`mailto:${e}`, e));
     case BuiltInFieldType.Address:
       return getAddressJsxElement(result.value);
     case BuiltInFieldType.RichText:
@@ -87,13 +86,25 @@ function getResultContent(result: FieldValueDirectAnswerType): JSX.Element {
       return <div>unknown</div>; //TODO: SLAP-2337
     default:
       return Array.isArray(result.value)
-        ? <div>{result.value.map((val, i) => <p key={i} className='block'>{val}</p>)}</div>
+        ? getListJsxElement(result.value, val => <p>{val}</p>)
         : <p>{result.value}</p>;
   }
 }
 
-function getUrlJsxElement(href: string, displayText?: string, key?: number): JSX.Element {
-  return <a {...{ href, key }} className='text-primary block'>{displayText ?? href}</a>;
+function getListJsxElement<T>(
+  value: T[],
+  getItemJsxElement: (el: T) => JSX.Element
+): JSX.Element {
+  return (<ul className='list-disc list-inside'>
+    {value.map((el, i) =>
+      <li key={i}>
+        {getItemJsxElement(el)}
+      </li>)}
+  </ul>);
+}
+
+function getUrlJsxElement(href: string, displayText?: string): JSX.Element {
+  return <a href={href} className='text-primary'>{displayText ?? href}</a>;
 }
 
 function getAddressJsxElement(address: Address): JSX.Element {

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -92,11 +92,11 @@ function getResultContent(result: FieldValueDirectAnswerType): JSX.Element {
 }
 
 function getListJsxElement<T>(
-  value: T[],
+  list: T[],
   getItemJsxElement: (el: T) => JSX.Element
 ): JSX.Element {
   return (<ul className='list-disc list-inside'>
-    {value.map((el, i) =>
+    {list.map((el, i) =>
       <li key={i}>
         {getItemJsxElement(el)}
       </li>)}

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -36,7 +36,7 @@ export function FieldValueDirectAnswer({
   cssClasses = {}
 }: FieldValueDirectAnswerProps): JSX.Element {
   const title = `${result.entityName} / ${result.fieldName}`;
-  const link = result.relatedResult.link;
+  const link = result.relatedResult.link ?? result.relatedResult.rawData.landingPageUrl;
   const resultContent = useMemo(() => getResultContent(result), [result]);
 
   return (

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -29,6 +29,8 @@ interface FieldValueDirectAnswerCssClasses {
 
 /**
  * Renders a field value direct answer provided by the Search API.
+ *
+ * @internal
  */
 export function FieldValueDirectAnswer({
   result,

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -1,6 +1,7 @@
 import {
   FieldValueDirectAnswer as FieldValueDirectAnswerType,
-  BuiltInFieldType
+  BuiltInFieldType,
+  Address
 } from '@yext/search-headless-react';
 import { useMemo } from 'react';
 
@@ -47,39 +48,51 @@ export function FieldValueDirectAnswer({
 function getResultContent(result: FieldValueDirectAnswerType): JSX.Element {
   switch (result.fieldType) {
     case BuiltInFieldType.InstagramHandle:
-      return <a href={`https://www.instagram.com/${result.value}`}>{result.value}</a>;
+      return getUrlJsxElement(`https://www.instagram.com/${result.value}`, result.value);
     case BuiltInFieldType.TwitterHandle:
-      return <a href={`https://twitter.com/${result.value}`}>@{result.value}</a>;
+      return getUrlJsxElement(`https://twitter.com/${result.value}`, `@${result.value}`);
     case BuiltInFieldType.FacebookURL:
     case BuiltInFieldType.AndroidAppURL:
     case BuiltInFieldType.IOSAppURL:
-      return <a href={result.value}>{result.value}</a>;
+      return getUrlJsxElement(result.value);
     case BuiltInFieldType.ComplexURL:
       const url = result.value.url;
-      return <a href={url}>{result.value.preferDisplayUrl ? result.value.displayUrl : url}</a>;
+      const displayUrl = result.value.preferDisplayUrl ? result.value.displayUrl : url;
+      return getUrlJsxElement(url, displayUrl);
     case BuiltInFieldType.URL:
       return Array.isArray(result.value)
-        ? <div>{result.value.map((url, i) => <a href={url} key={i}>{url}</a>)}</div>
-        : <a href={result.value}>{result.value}</a>;
+        ? <div>{result.value.map((url, i) => getUrlJsxElement(url, url, i))}</div>
+        : getUrlJsxElement(result.value);
     case BuiltInFieldType.Phone:
-      return <a href={`tel:${result.value}`}>{result.value}</a>;
+      return getUrlJsxElement(`tel:${result.value}`, result.value);
     case BuiltInFieldType.Email:
-      return <div>{result.value.map((email, i) => <a href={`mailto:${email}`} key={i}>{email}</a>)}</div>;
+      return <div>{result.value.map((email, i) => getUrlJsxElement(`mailto:${email}`, email, i))}</div>;
     case BuiltInFieldType.Address:
-      return <p>{result.value}</p>; //TODO: components__address__i18n__addressForCountry in theme (2500 lines)
+      return getAddressJsxElement(result.value);
     case BuiltInFieldType.RichText:
-      return <p>{result.value}</p>; //TODO: require formatter? RtfConverter for rich text.
+      return <div>rich text</div>; //TODO: use react-markdown
     case 'unknown':
-      console.warn('unknown type');
-      return <div>unknown</div>; //TODO: future item
+      return <div>unknown</div>; //TODO: SLAP-2337
     default:
-      /**
-       * DecimalDirectAnswer (string | string[])
-       * IntegerDirectAnswer (number)
-       * TextDirectAnswer (string | string[])
-       */
       return Array.isArray(result.value)
-        ? <div>{result.value.map((val, i) => <p key={i}>{val}</p>)}</div>
+        ? <div>{result.value.map((val, i) => <p key={i} className='block'>{val}</p>)}</div>
         : <p>{result.value}</p>;
   }
+}
+
+function getUrlJsxElement(href: string, displayText?: string, key?: number) {
+  return <a {...{ href, key }} className='text-primary block'>{displayText ?? href}</a>;
+}
+
+function getAddressJsxElement(address: Address): JSX.Element {
+  if (address.extraDescription) {
+    return <div>{address.extraDescription}</div>;
+  }
+  return <div>
+    {address.line1 && <p>{address.line1}</p>}
+    {address.line2 && <p>{address.line2}</p>}
+    {address.line3 && <p>{address.line3}</p>}
+    <p>{address.city}, {address.region} {address.postalCode}</p>
+    <p>{address.countryCode}</p>
+  </div>;
 }

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -5,12 +5,21 @@ import {
 } from '@yext/search-headless-react';
 import { useMemo } from 'react';
 
+/**
+ * Props for FieldValueDirectAnswer.
+ */
 interface FieldValueDirectAnswerProps {
+  /** A field value direct answer result. */
   result: FieldValueDirectAnswerType,
-  handleClickViewDetails: () => void,
+  /** Handle onClick event for "View Details" link. */
+  viewDetailsClickHandler: () => void,
+  /** CSS classes for customizing the component styling. */
   cssClasses?: FieldValueDirectAnswerCssClasses
 }
 
+/**
+ *  The CSS class interface for FieldValueDirectAnswer.
+ */
 interface FieldValueDirectAnswerCssClasses {
   header?: string,
   body?: string,
@@ -18,9 +27,12 @@ interface FieldValueDirectAnswerCssClasses {
   answerContainer?: string
 }
 
+/**
+ * Renders a field value direct answer provided by the Search API.
+ */
 export function FieldValueDirectAnswer({
   result,
-  handleClickViewDetails,
+  viewDetailsClickHandler,
   cssClasses = {}
 }: FieldValueDirectAnswerProps): JSX.Element {
   const title = `${result.entityName} / ${result.fieldName}`;
@@ -36,7 +48,7 @@ export function FieldValueDirectAnswer({
         {link && <a
           href={link}
           className='text-primary pt-4 text-neutral'
-          onClick={handleClickViewDetails}
+          onClick={viewDetailsClickHandler}
         >
           View Details
         </a>}
@@ -66,7 +78,7 @@ function getResultContent(result: FieldValueDirectAnswerType): JSX.Element {
     case BuiltInFieldType.Phone:
       return getUrlJsxElement(`tel:${result.value}`, result.value);
     case BuiltInFieldType.Email:
-      return <div>{result.value.map((email, i) => getUrlJsxElement(`mailto:${email}`, email, i))}</div>;
+      return <div>{result.value.map((e, i) => getUrlJsxElement(`mailto:${e}`, e, i))}</div>;
     case BuiltInFieldType.Address:
       return getAddressJsxElement(result.value);
     case BuiltInFieldType.RichText:
@@ -80,11 +92,12 @@ function getResultContent(result: FieldValueDirectAnswerType): JSX.Element {
   }
 }
 
-function getUrlJsxElement(href: string, displayText?: string, key?: number) {
+function getUrlJsxElement(href: string, displayText?: string, key?: number): JSX.Element {
   return <a {...{ href, key }} className='text-primary block'>{displayText ?? href}</a>;
 }
 
 function getAddressJsxElement(address: Address): JSX.Element {
+  // user specified display Address in KM
   if (address.extraDescription) {
     return <div>{address.extraDescription}</div>;
   }

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -1,0 +1,85 @@
+import {
+  FieldValueDirectAnswer as FieldValueDirectAnswerType,
+  BuiltInFieldType
+} from '@yext/search-headless-react';
+import { useMemo } from 'react';
+
+interface FieldValueDirectAnswerProps {
+  result: FieldValueDirectAnswerType,
+  handleClickViewDetails: () => void,
+  cssClasses?: FieldValueDirectAnswerCssClasses
+}
+
+interface FieldValueDirectAnswerCssClasses {
+  header?: string,
+  body?: string,
+  content?: string,
+  answerContainer?: string
+}
+
+export function FieldValueDirectAnswer({
+  result,
+  handleClickViewDetails,
+  cssClasses = {}
+}: FieldValueDirectAnswerProps): JSX.Element {
+  const title = `${result.entityName} / ${result.fieldName}`;
+  const link = result.relatedResult.link;
+  const description = useMemo(() => getResultContent(result), [result]);
+
+  return (
+    <div className={cssClasses.answerContainer}>
+      {title &&
+      <div className={cssClasses.header}>{title}</div>}
+      <div className={cssClasses.content}>
+        <div className={cssClasses.body}>{description}</div>
+        {link && <a
+          href={link}
+          className='text-primary pt-4 text-neutral'
+          onClick={handleClickViewDetails}
+        >
+          View Details
+        </a>}
+      </div>
+    </div>
+  );
+}
+
+function getResultContent(result: FieldValueDirectAnswerType): JSX.Element {
+  switch (result.fieldType) {
+    case BuiltInFieldType.InstagramHandle:
+      return <a href={`https://www.instagram.com/${result.value}`}>{result.value}</a>;
+    case BuiltInFieldType.TwitterHandle:
+      return <a href={`https://twitter.com/${result.value}`}>@{result.value}</a>;
+    case BuiltInFieldType.FacebookURL:
+    case BuiltInFieldType.AndroidAppURL:
+    case BuiltInFieldType.IOSAppURL:
+      return <a href={result.value}>{result.value}</a>;
+    case BuiltInFieldType.ComplexURL:
+      const url = result.value.url;
+      return <a href={url}>{result.value.preferDisplayUrl ? result.value.displayUrl : url}</a>;
+    case BuiltInFieldType.URL:
+      return Array.isArray(result.value)
+        ? <div>{result.value.map((url, i) => <a href={url} key={i}>{url}</a>)}</div>
+        : <a href={result.value}>{result.value}</a>;
+    case BuiltInFieldType.Phone:
+      return <a href={`tel:${result.value}`}>{result.value}</a>;
+    case BuiltInFieldType.Email:
+      return <div>{result.value.map((email, i) => <a href={`mailto:${email}`} key={i}>{email}</a>)}</div>;
+    case BuiltInFieldType.Address:
+      return <p>{result.value}</p>; //TODO: components__address__i18n__addressForCountry in theme (2500 lines)
+    case BuiltInFieldType.RichText:
+      return <p>{result.value}</p>; //TODO: require formatter? RtfConverter for rich text.
+    case 'unknown':
+      console.warn('unknown type');
+      return <div>unknown</div>; //TODO: future item
+    default:
+      /**
+       * DecimalDirectAnswer (string | string[])
+       * IntegerDirectAnswer (number)
+       * TextDirectAnswer (string | string[])
+       */
+      return Array.isArray(result.value)
+        ? <div>{result.value.map((val, i) => <p key={i}>{val}</p>)}</div>
+        : <p>{result.value}</p>;
+  }
+}

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -61,25 +61,25 @@ export function FieldValueDirectAnswer({
 function getResultContent(result: FieldValueDirectAnswerType): JSX.Element {
   switch (result.fieldType) {
     case BuiltInFieldType.InstagramHandle:
-      return getUrlJsxElement(`https://www.instagram.com/${result.value}`, result.value);
+      return getAnchorTagJsxElement(`https://www.instagram.com/${result.value}`, result.value);
     case BuiltInFieldType.TwitterHandle:
-      return getUrlJsxElement(`https://twitter.com/${result.value}`, `@${result.value}`);
+      return getAnchorTagJsxElement(`https://twitter.com/${result.value}`, `@${result.value}`);
     case BuiltInFieldType.FacebookURL:
     case BuiltInFieldType.AndroidAppURL:
     case BuiltInFieldType.IOSAppURL:
-      return getUrlJsxElement(result.value);
+      return getAnchorTagJsxElement(result.value);
     case BuiltInFieldType.ComplexURL:
       const url = result.value.url;
       const displayUrl = result.value.preferDisplayUrl ? result.value.displayUrl : url;
-      return getUrlJsxElement(url, displayUrl);
+      return getAnchorTagJsxElement(url, displayUrl);
     case BuiltInFieldType.URL:
       return Array.isArray(result.value)
-        ? getListJsxElement(result.value, url => getUrlJsxElement(url))
-        : getUrlJsxElement(result.value);
+        ? getListJsxElement(result.value, url => getAnchorTagJsxElement(url))
+        : getAnchorTagJsxElement(result.value);
     case BuiltInFieldType.Phone:
-      return getUrlJsxElement(`tel:${result.value}`, result.value);
+      return getAnchorTagJsxElement(`tel:${result.value}`, result.value);
     case BuiltInFieldType.Email:
-      return getListJsxElement(result.value, e => getUrlJsxElement(`mailto:${e}`, e));
+      return getListJsxElement(result.value, e => getAnchorTagJsxElement(`mailto:${e}`, e));
     case BuiltInFieldType.Address:
       return getAddressJsxElement(result.value);
     case BuiltInFieldType.RichText:
@@ -105,7 +105,7 @@ function getListJsxElement<T>(
   </ul>);
 }
 
-function getUrlJsxElement(href: string, displayText?: string): JSX.Element {
+function getAnchorTagJsxElement(href: string, displayText?: string): JSX.Element {
   return <a href={href} className='text-primary'>{displayText ?? href}</a>;
 }
 

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -83,7 +83,7 @@ function getResultContent(result: FieldValueDirectAnswerType): JSX.Element {
     case BuiltInFieldType.Address:
       return getAddressJsxElement(result.value);
     case BuiltInFieldType.RichText:
-      return <div>rich text</div>; //TODO: use react-markdown
+      return <div>{result.value}</div>; //TODO: SLAP-2340
     case 'unknown':
       return <div>unknown</div>; //TODO: SLAP-2337
     default:

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -114,14 +114,14 @@ function getAddressJsxElement(address: Address): JSX.Element {
   if (address.extraDescription) {
     return <div>{address.extraDescription}</div>;
   }
-  const cityFormat = address.city ? address.city + ',' : '';
-  const cityRegionPostalCodeFormat = [cityFormat, address.region, address.postalCode].join(' ').trim();
+  const formattedCity = address.city ? address.city + ',' : '';
+  const formattedCityRegionPostalCode = [formattedCity, address.region, address.postalCode].join(' ').trim();
 
   return <div>
     {address.line1 && <p>{address.line1}</p>}
     {address.line2 && <p>{address.line2}</p>}
     {address.line3 && <p>{address.line3}</p>}
-    {cityRegionPostalCodeFormat && <p>{cityRegionPostalCodeFormat}</p>}
+    {formattedCityRegionPostalCode && <p>{formattedCityRegionPostalCode}</p>}
     <p>{address.countryCode}</p>
   </div>;
 }

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -36,7 +36,7 @@ export function FieldValueDirectAnswer({
   cssClasses = {}
 }: FieldValueDirectAnswerProps): JSX.Element {
   const title = `${result.entityName} / ${result.fieldName}`;
-  const link = result.relatedResult.link ?? result.relatedResult.rawData.landingPageUrl;
+  const link = result.relatedResult.link ?? result.relatedResult.rawData.landingPageUrl as string;
   const resultContent = useMemo(() => getResultContent(result), [result]);
 
   return (

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -86,8 +86,8 @@ function getResultContent(result: FieldValueDirectAnswerType): JSX.Element {
       return <div>unknown</div>; //TODO: SLAP-2337
     default:
       return Array.isArray(result.value)
-        ? getListJsxElement(result.value, val => <p>{val}</p>)
-        : <p>{result.value}</p>;
+        ? getListJsxElement(result.value, val => <p className='whitespace-pre-wrap'>{val}</p>)
+        : <p className='whitespace-pre-wrap'>{result.value}</p>;
   }
 }
 

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -114,11 +114,14 @@ function getAddressJsxElement(address: Address): JSX.Element {
   if (address.extraDescription) {
     return <div>{address.extraDescription}</div>;
   }
+  const cityFormat = address.city ? address.city + ',' : '';
+  const cityRegionPostalCodeFormat = [cityFormat, address.region, address.postalCode].join(' ').trim();
+
   return <div>
     {address.line1 && <p>{address.line1}</p>}
     {address.line2 && <p>{address.line2}</p>}
     {address.line3 && <p>{address.line3}</p>}
-    <p>{address.city}, {address.region} {address.postalCode}</p>
+    {cityRegionPostalCodeFormat && <p>{cityRegionPostalCodeFormat}</p>}
     <p>{address.countryCode}</p>
   </div>;
 }

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -37,14 +37,14 @@ export function FieldValueDirectAnswer({
 }: FieldValueDirectAnswerProps): JSX.Element {
   const title = `${result.entityName} / ${result.fieldName}`;
   const link = result.relatedResult.link;
-  const description = useMemo(() => getResultContent(result), [result]);
+  const resultContent = useMemo(() => getResultContent(result), [result]);
 
   return (
     <div className={cssClasses.answerContainer}>
       {title &&
       <div className={cssClasses.header}>{title}</div>}
       <div className={cssClasses.content}>
-        <div className={cssClasses.body}>{description}</div>
+        <div className={cssClasses.body}>{resultContent}</div>
         {link && <div className='mt-4'>
           <a href={link} className='text-primary' onClick={viewDetailsClickHandler}>
             View Details

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -12,7 +12,7 @@ interface FieldValueDirectAnswerProps {
   /** A field value direct answer result. */
   result: FieldValueDirectAnswerType,
   /** Handle onClick event for "View Details" link. */
-  viewDetailsClickHandler: () => void,
+  viewDetailsClickHandler?: () => void,
   /** CSS classes for customizing the component styling. */
   cssClasses?: FieldValueDirectAnswerCssClasses
 }

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -72,7 +72,7 @@
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/eslint-config-slapshot": "^0.5.0",
-        "@yext/search-headless-react": "^2.0.0-alpha.151",
+        "@yext/search-headless-react": "^2.0.0-alpha.152",
         "axe-playwright": "^1.1.11",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",
@@ -90,7 +90,7 @@
         "typescript": "~4.4.3"
       },
       "peerDependencies": {
-        "@yext/search-headless-react": "^2.0.0-alpha.151",
+        "@yext/search-headless-react": "^2.0.0-alpha.152",
         "react": "^16.14 || ^17 || ^18"
       }
     },
@@ -35317,7 +35317,7 @@
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/analytics": "^0.2.0-beta.3",
         "@yext/eslint-config-slapshot": "^0.5.0",
-        "@yext/search-headless-react": "^2.0.0-alpha.151",
+        "@yext/search-headless-react": "^2.0.0-alpha.152",
         "axe-playwright": "^1.1.11",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",

--- a/tests/__fixtures__/data/directanswers.ts
+++ b/tests/__fixtures__/data/directanswers.ts
@@ -17,7 +17,7 @@ export const featuredSnippetDAState: RecursivePartial<DirectAnswerState> = {
   }
 };
 
-export const fieldValueDAState: RecursivePartial<DirectAnswerState> = {
+export const fieldValueDAState: DirectAnswerState = {
   result: {
     type: DirectAnswerType.FieldValue,
     entityName: '[entityName]',

--- a/tests/__fixtures__/data/directanswers.ts
+++ b/tests/__fixtures__/data/directanswers.ts
@@ -1,4 +1,4 @@
-import { DirectAnswerState, DirectAnswerType } from '@yext/search-headless-react';
+import { BuiltInFieldType, DirectAnswerState, DirectAnswerType, Source } from '@yext/search-headless-react';
 import { RecursivePartial } from '../../__utils__/mocks';
 
 export const featuredSnippetDAState: RecursivePartial<DirectAnswerState> = {
@@ -22,10 +22,15 @@ export const fieldValueDAState: RecursivePartial<DirectAnswerState> = {
     type: DirectAnswerType.FieldValue,
     entityName: '[entityName]',
     fieldName: '[fieldName]',
+    fieldType: BuiltInFieldType.SingleLineText,
+    fieldApiName: '[fieldApiName]',
+    verticalKey: '[verticalKey]',
     value: '[value]',
     relatedResult: {
       link: '[relatedResult.link]',
-      id: '[relatedResult.id]'
+      id: '[relatedResult.id]',
+      rawData: {},
+      source: Source.KnowledgeManager
     }
   }
 };

--- a/tests/components/DirectAnswer.stories.tsx
+++ b/tests/components/DirectAnswer.stories.tsx
@@ -18,7 +18,7 @@ const meta: ComponentMeta<typeof DirectAnswer> = {
 };
 export default meta;
 
-const baseDirectAnswerResult = fieldValueDAState.result as FieldValueDirectAnswerType;
+const baseDirectAnswerResult = fieldValueDAState.result;
 
 function generateFieldValueDirectAnswer(
   args: DirectAnswerProps,

--- a/tests/components/DirectAnswer.stories.tsx
+++ b/tests/components/DirectAnswer.stories.tsx
@@ -1,10 +1,8 @@
 import { ComponentMeta } from '@storybook/react';
 import {
   BuiltInFieldType,
-  DirectAnswerType,
   SearchHeadlessContext,
   FieldValueDirectAnswer as FieldValueDirectAnswerType,
-  Source,
   ComplexURL,
   Address
 } from '@yext/search-headless-react';
@@ -12,8 +10,7 @@ import {
 import { DirectAnswer, DirectAnswerProps } from '../../src/components/DirectAnswer';
 
 import { generateMockedHeadless } from '../__fixtures__/search-headless';
-import { featuredSnippetDAState } from '../__fixtures__/data/directanswers';
-import { RecursivePartial } from '../__utils__/mocks';
+import { featuredSnippetDAState, fieldValueDAState } from '../__fixtures__/data/directanswers';
 
 const meta: ComponentMeta<typeof DirectAnswer> = {
   title: 'DirectAnswer',
@@ -21,19 +18,7 @@ const meta: ComponentMeta<typeof DirectAnswer> = {
 };
 export default meta;
 
-const baseDirectAnswerResult: RecursivePartial<FieldValueDirectAnswerType> = {
-  type: DirectAnswerType.FieldValue,
-  entityName: '[entityName]',
-  fieldName: '[fieldName]',
-  fieldType: 'unknown',
-  value: '[value]',
-  relatedResult: {
-    link: '[relatedResult.link]',
-    id: '[relatedResult.id]',
-    rawData: {},
-    source: Source.KnowledgeManager
-  }
-};
+const baseDirectAnswerResult = fieldValueDAState.result as FieldValueDirectAnswerType;
 
 function generateFieldValueDirectAnswer(
   args: DirectAnswerProps,

--- a/tests/components/DirectAnswer.stories.tsx
+++ b/tests/components/DirectAnswer.stories.tsx
@@ -91,7 +91,7 @@ export const AddressFieldValue = (args: DirectAnswerProps) => {
 };
 
 export const StringFieldValue = (args: DirectAnswerProps) => {
-  return generateFieldValueDirectAnswer(args, BuiltInFieldType.MultiLineText, '[value]');
+  return generateFieldValueDirectAnswer(args, BuiltInFieldType.MultiLineText, 'multi\nline\ntext');
 };
 
 export const NumberFieldValue = (args: DirectAnswerProps) => {

--- a/tests/components/DirectAnswer.stories.tsx
+++ b/tests/components/DirectAnswer.stories.tsx
@@ -6,7 +6,8 @@ import {
   FieldValueDirectAnswer as FieldValueDirectAnswerType,
   Source,
   ComplexURL,
-  Address} from '@yext/search-headless-react';
+  Address
+} from '@yext/search-headless-react';
 
 import { DirectAnswer, DirectAnswerProps } from '../../src/components/DirectAnswer';
 

--- a/tests/components/DirectAnswer.stories.tsx
+++ b/tests/components/DirectAnswer.stories.tsx
@@ -1,10 +1,18 @@
 import { ComponentMeta } from '@storybook/react';
-import { SearchHeadlessContext } from '@yext/search-headless-react';
+import {
+  BuiltInFieldType,
+  DirectAnswerType,
+  SearchHeadlessContext,
+  FieldValueDirectAnswer as FieldValueDirectAnswerType,
+  Source,
+  ComplexURL,
+  Address} from '@yext/search-headless-react';
 
 import { DirectAnswer, DirectAnswerProps } from '../../src/components/DirectAnswer';
 
 import { generateMockedHeadless } from '../__fixtures__/search-headless';
-import { featuredSnippetDAState, fieldValueDAState } from '../__fixtures__/data/directanswers';
+import { featuredSnippetDAState } from '../__fixtures__/data/directanswers';
+import { RecursivePartial } from '../__utils__/mocks';
 
 const meta: ComponentMeta<typeof DirectAnswer> = {
   title: 'DirectAnswer',
@@ -12,14 +20,81 @@ const meta: ComponentMeta<typeof DirectAnswer> = {
 };
 export default meta;
 
-export const FieldValue = (args: DirectAnswerProps) => {
+const baseDirectAnswerResult: RecursivePartial<FieldValueDirectAnswerType> = {
+  type: DirectAnswerType.FieldValue,
+  entityName: '[entityName]',
+  fieldName: '[fieldName]',
+  fieldType: 'unknown',
+  value: '[value]',
+  relatedResult: {
+    link: '[relatedResult.link]',
+    id: '[relatedResult.id]',
+    rawData: {},
+    source: Source.KnowledgeManager
+  }
+};
+
+function generateFieldValueDirectAnswer(
+  args: DirectAnswerProps,
+  fieldType?: FieldValueDirectAnswerType['fieldType'],
+  value?: unknown,
+): JSX.Element {
   return (
     <SearchHeadlessContext.Provider value={generateMockedHeadless({
-      directAnswer: fieldValueDAState
+      directAnswer: {
+        result: {
+          ...baseDirectAnswerResult,
+          ...(fieldType !== undefined && { fieldType }),
+          ...(value !== undefined && { value }),
+        } as FieldValueDirectAnswerType
+      }
     })}>
       <DirectAnswer {...args} />
     </SearchHeadlessContext.Provider>
   );
+}
+
+export const URLFieldValue = (args: DirectAnswerProps) => {
+  return generateFieldValueDirectAnswer(args, BuiltInFieldType.URL, '[url]');
+};
+
+export const ComplexURLFieldValue = (args: DirectAnswerProps) => {
+  const complexUrl: ComplexURL = {
+    url: '[url]',
+    displayUrl: '[displayUrl]',
+    preferDisplayUrl: true
+  };
+  return generateFieldValueDirectAnswer(args, BuiltInFieldType.ComplexURL, complexUrl);
+};
+
+export const ListFieldValue = (args: DirectAnswerProps) => {
+  const emails = [
+    'email1@yext.com',
+    'email2@yext.com',
+    'email3@yext.com'
+  ];
+  return generateFieldValueDirectAnswer(args, BuiltInFieldType.Email, emails);
+};
+
+export const AddressFieldValue = (args: DirectAnswerProps) => {
+  const address: Address = {
+    line1: '[line1]',
+    line2: '[line2]',
+    line3: '[line3]',
+    city: '[city]',
+    region: '[region]',
+    postalCode: '[postalCode]',
+    countryCode: '[countryCode]'
+  };
+  return generateFieldValueDirectAnswer(args, BuiltInFieldType.Address, address);
+};
+
+export const StringFieldValue = (args: DirectAnswerProps) => {
+  return generateFieldValueDirectAnswer(args, BuiltInFieldType.MultiLineText, '[value]');
+};
+
+export const NumberFieldValue = (args: DirectAnswerProps) => {
+  return generateFieldValueDirectAnswer(args, BuiltInFieldType.Integer, 123456789);
 };
 
 export const FeaturedSnippet = (args: DirectAnswerProps) => {

--- a/tests/components/DirectAnswer.test.tsx
+++ b/tests/components/DirectAnswer.test.tsx
@@ -21,61 +21,17 @@ it('renders null when there is no direct answer in state', () => {
   expect(container).toBeEmptyDOMElement();
 });
 
-describe('FieldValue direct answer', () => {
+describe('Field value direct answer analytics', () => {
   beforeEach(() => mockState(fieldValueDAState));
-
-  it('title text', () => {
-    render(<DirectAnswer />);
-    const expectedTitle = '[entityName] / [fieldName]';
-    expect(screen.getByText(expectedTitle)).toBeInTheDocument();
-  });
-
-  it('description text', () => {
-    render(<DirectAnswer />);
-    const expectedDescription = '[value]';
-    expect(screen.getByText(expectedDescription)).toBeInTheDocument();
-  });
-
-  it('link', () => {
-    render(<DirectAnswer />);
-    const directAnswerLink = screen.getByRole('link');
-    expect(directAnswerLink).toHaveTextContent('View Details');
-    expect(directAnswerLink).toHaveAttribute('href', '[relatedResult.link]');
-  });
-
   runAnalyticsTestSuite();
 });
 
-describe('FeaturedSnippet direct answer', () => {
+describe('Featured snippet direct answer analytics', () => {
   beforeEach(() => mockState(featuredSnippetDAState));
-
-  it('title text', () => {
-    render(<DirectAnswer />);
-    const expectedTitle = '[value]';
-    expect(screen.getByText(expectedTitle)).toBeInTheDocument();
+  it('TODO: SLAP-2335', () => {
+    console.log('TODO: SLAP-2335');
   });
-
-  it('description text is highlighted', () => {
-    render(<DirectAnswer />);
-
-    const unhighlightedAtStart = screen.getByText('[');
-    expect(unhighlightedAtStart).toBeDefined();
-
-    const highlighted = screen.getByText('snip');
-    expect(highlighted).toBeDefined();
-
-    const unhighlightedAtEnd = screen.getByText('pet.value]');
-    expect(unhighlightedAtEnd).toBeDefined();
-  });
-
-  it('link', () => {
-    render(<DirectAnswer />);
-    const directAnswerLink = screen.getByRole('link');
-    expect(directAnswerLink).toHaveTextContent('[relatedResult.name]');
-    expect(directAnswerLink).toHaveAttribute('href', '[relatedResult.link]');
-  });
-
-  runAnalyticsTestSuite();
+  // runAnalyticsTestSuite(); TODO: SLAP-2335
 });
 
 function runAnalyticsTestSuite() {
@@ -83,8 +39,8 @@ function runAnalyticsTestSuite() {
     render(<DirectAnswer />);
     const link = screen.getByRole('link');
     userEvent.click(link);
-    expect(useAnalytics().report).toHaveBeenCalledTimes(1);
-    expect(useAnalytics().report).toHaveBeenCalledWith(expect.objectContaining({
+    expect(useAnalytics()?.report).toHaveBeenCalledTimes(1);
+    expect(useAnalytics()?.report).toHaveBeenCalledWith(expect.objectContaining({
       type: 'CTA_CLICK',
       queryId: '[queryId]',
       searcher: 'UNIVERSAL',
@@ -96,8 +52,8 @@ function runAnalyticsTestSuite() {
     render(<DirectAnswer />);
     const thumbsUp = screen.queryAllByRole('button')[0];
     userEvent.click(thumbsUp);
-    expect(useAnalytics().report).toHaveBeenCalledTimes(1);
-    expect(useAnalytics().report).toHaveBeenCalledWith(expect.objectContaining({
+    expect(useAnalytics()?.report).toHaveBeenCalledTimes(1);
+    expect(useAnalytics()?.report).toHaveBeenCalledWith(expect.objectContaining({
       type: 'THUMBS_UP',
       queryId: '[queryId]',
       searcher: 'UNIVERSAL',
@@ -109,8 +65,8 @@ function runAnalyticsTestSuite() {
     render(<DirectAnswer />);
     const thumbsDown = screen.queryAllByRole('button')[1];
     userEvent.click(thumbsDown);
-    expect(useAnalytics().report).toHaveBeenCalledTimes(1);
-    expect(useAnalytics().report).toHaveBeenCalledWith(expect.objectContaining({
+    expect(useAnalytics()?.report).toHaveBeenCalledTimes(1);
+    expect(useAnalytics()?.report).toHaveBeenCalledWith(expect.objectContaining({
       type: 'THUMBS_DOWN',
       queryId: '[queryId]',
       searcher: 'UNIVERSAL',

--- a/tests/components/DirectAnswer.test.tsx
+++ b/tests/components/DirectAnswer.test.tsx
@@ -28,10 +28,7 @@ describe('Field value direct answer analytics', () => {
 
 describe('Featured snippet direct answer analytics', () => {
   beforeEach(() => mockState(featuredSnippetDAState));
-  it('TODO: SLAP-2335', () => {
-    console.log('TODO: SLAP-2335');
-  });
-  // runAnalyticsTestSuite(); TODO: SLAP-2335
+  runAnalyticsTestSuite();
 });
 
 function runAnalyticsTestSuite() {

--- a/tests/components/DirectAnswer.test.tsx
+++ b/tests/components/DirectAnswer.test.tsx
@@ -26,8 +26,35 @@ describe('Field value direct answer analytics', () => {
   runAnalyticsTestSuite();
 });
 
-describe('Featured snippet direct answer analytics', () => {
+describe('FeaturedSnippet direct answer', () => {
   beforeEach(() => mockState(featuredSnippetDAState));
+
+  it('title text', () => {
+    render(<DirectAnswer />);
+    const expectedTitle = '[value]';
+    expect(screen.getByText(expectedTitle)).toBeInTheDocument();
+  });
+
+  it('description text is highlighted', () => {
+    render(<DirectAnswer />);
+
+    const unhighlightedAtStart = screen.getByText('[');
+    expect(unhighlightedAtStart).toBeDefined();
+
+    const highlighted = screen.getByText('snip');
+    expect(highlighted).toBeDefined();
+
+    const unhighlightedAtEnd = screen.getByText('pet.value]');
+    expect(unhighlightedAtEnd).toBeDefined();
+  });
+
+  it('link', () => {
+    render(<DirectAnswer />);
+    const directAnswerLink = screen.getByRole('link');
+    expect(directAnswerLink).toHaveTextContent('[relatedResult.name]');
+    expect(directAnswerLink).toHaveAttribute('href', '[relatedResult.link]');
+  });
+
   runAnalyticsTestSuite();
 });
 

--- a/tests/components/FieldValueDirectAnswer.test.tsx
+++ b/tests/components/FieldValueDirectAnswer.test.tsx
@@ -31,6 +31,26 @@ describe('FieldValue direct answer', () => {
     expect(viewDetailsClickHandler).toHaveBeenCalledTimes(1);
   });
 
+  it('use relatedResult.link url for "View Details" link', () => {
+    render(<FieldValueDirectAnswer result={fieldValueDAResult} />);
+    expect(screen.getByRole('link', { name: 'View Details' })).toHaveAttribute('href', '[relatedResult.link]');
+  });
+
+  it('uses landingPageUrl as fallback url for "View Details" link', () => {
+    render(<FieldValueDirectAnswer
+      result={{
+        ...fieldValueDAResult,
+        relatedResult: {
+          rawData: {
+            landingPageUrl: '[landingPageUrl]'
+          },
+          source: Source.KnowledgeManager
+        }
+      }}
+    />);
+    expect(screen.getByRole('link', { name: 'View Details' })).toHaveAttribute('href', '[landingPageUrl]');
+  });
+
   it('contains proper url href for simple URL field types', () => {
     const urlTypes = [
       BuiltInFieldType.IOSAppURL,

--- a/tests/components/FieldValueDirectAnswer.test.tsx
+++ b/tests/components/FieldValueDirectAnswer.test.tsx
@@ -132,7 +132,7 @@ describe('FieldValue direct answer', () => {
       city: 'New York',
       region: 'NY',
       postalCode: '10011',
-      countryCode: 'NY',
+      countryCode: 'US',
       extraDescription
     };
     const result = {

--- a/tests/components/FieldValueDirectAnswer.test.tsx
+++ b/tests/components/FieldValueDirectAnswer.test.tsx
@@ -150,6 +150,4 @@ describe('FieldValue direct answer', () => {
     render(<FieldValueDirectAnswer result={result}/>);
     expect(screen.getByText(extraDescription)).toBeDefined();
   });
-
-  //TODO: test for rich text
 });

--- a/tests/components/FieldValueDirectAnswer.test.tsx
+++ b/tests/components/FieldValueDirectAnswer.test.tsx
@@ -1,23 +1,10 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { FieldValueDirectAnswer } from '../../src/components/FieldValueDirectAnswer';
-import { Address, BuiltInFieldType, DirectAnswerType, FieldValueDirectAnswer as FieldValueDirectAnswerType, Source } from '@yext/search-headless-react';
+import { Address, BuiltInFieldType, FieldValueDirectAnswer as FieldValueDirectAnswerType, Source } from '@yext/search-headless-react';
 import { userEvent } from '@storybook/testing-library';
+import { fieldValueDAState } from '../__fixtures__/data/directanswers';
 
-const fieldValueDAResult: FieldValueDirectAnswerType = {
-  type: DirectAnswerType.FieldValue,
-  entityName: '[entityName]',
-  fieldName: '[fieldName]',
-  fieldType: BuiltInFieldType.SingleLineText,
-  fieldApiName: '[fieldApiName]',
-  verticalKey: '[verticalKey]',
-  value: '[value]',
-  relatedResult: {
-    link: '[relatedResult.link]',
-    id: '[relatedResult.id]',
-    rawData: {},
-    source: Source.KnowledgeManager
-  }
-};
+const fieldValueDAResult = fieldValueDAState.result as FieldValueDirectAnswerType;
 
 describe('FieldValue direct answer', () => {
 

--- a/tests/components/FieldValueDirectAnswer.test.tsx
+++ b/tests/components/FieldValueDirectAnswer.test.tsx
@@ -1,0 +1,148 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { FieldValueDirectAnswer } from '../../src/components/FieldValueDirectAnswer';
+import { Address, BuiltInFieldType, DirectAnswerType, FieldValueDirectAnswer as FieldValueDirectAnswerType, Source } from '@yext/search-headless-react';
+import { userEvent } from '@storybook/testing-library';
+
+const fieldValueDAResult: FieldValueDirectAnswerType = {
+  type: DirectAnswerType.FieldValue,
+  entityName: '[entityName]',
+  fieldName: '[fieldName]',
+  fieldType: BuiltInFieldType.SingleLineText,
+  fieldApiName: '[fieldApiName]',
+  verticalKey: '[verticalKey]',
+  value: '[value]',
+  relatedResult: {
+    link: '[relatedResult.link]',
+    id: '[relatedResult.id]',
+    rawData: {},
+    source: Source.KnowledgeManager
+  }
+};
+
+describe('FieldValue direct answer', () => {
+
+  it('executes viewDetailsClickHandler when click on "View Details" link', () => {
+    const viewDetailsClickHandler = jest.fn();
+    render(<FieldValueDirectAnswer
+      result={fieldValueDAResult}
+      viewDetailsClickHandler={viewDetailsClickHandler}/>
+    );
+    userEvent.click(screen.getByRole('link', { name: 'View Details' }));
+    expect(viewDetailsClickHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('contains proper url href for simple URL field types', () => {
+    const urlTypes = [
+      BuiltInFieldType.IOSAppURL,
+      BuiltInFieldType.AndroidAppURL,
+      BuiltInFieldType.FacebookURL,
+      BuiltInFieldType.URL
+    ];
+    urlTypes.forEach((fieldType) => {
+      const value = `https://www.${fieldType}.com/`;
+      const result = { ...fieldValueDAResult, fieldType, value } as FieldValueDirectAnswerType;
+      render(<FieldValueDirectAnswer result={result}/>);
+      expect(screen.getByRole('link', { name: value })).toHaveAttribute('href', value);
+      cleanup();
+    });
+  });
+
+  it('contains proper url href for field type "InstagramHandle"', () => {
+    const result = {
+      ...fieldValueDAResult,
+      fieldType: BuiltInFieldType.InstagramHandle
+    } as FieldValueDirectAnswerType;
+    render(<FieldValueDirectAnswer result={result}/>);
+    expect(screen.getByRole('link', { name: '[value]' }))
+      .toHaveAttribute('href', 'https://www.instagram.com/[value]');
+  });
+
+  it('contains proper url href for field type "TwitterHandle"', () => {
+    const result = {
+      ...fieldValueDAResult,
+      fieldType: BuiltInFieldType.TwitterHandle
+    } as FieldValueDirectAnswerType;
+    render(<FieldValueDirectAnswer result={result}/>);
+    expect(screen.getByRole('link', { name: '@[value]' }))
+      .toHaveAttribute('href', 'https://twitter.com/[value]');
+  });
+
+  it('contains proper url href for field type "ComplexURL"', () => {
+    const result = {
+      ...fieldValueDAResult,
+      fieldType: BuiltInFieldType.ComplexURL,
+      value: {
+        url: '[url]',
+        displayUrl: '[preferUrl]',
+        preferDisplayUrl: false,
+      }
+    } as FieldValueDirectAnswerType;
+    render(<FieldValueDirectAnswer result={result}/>);
+    expect(screen.getByRole('link', { name: '[url]' }))
+      .toHaveAttribute('href', '[url]');
+  });
+
+  it('displays the preferred displayUrl for field type "ComplexURL"', () => {
+    const result = {
+      ...fieldValueDAResult,
+      fieldType: BuiltInFieldType.ComplexURL,
+      value: {
+        url: '[url]',
+        displayUrl: '[preferUrl]',
+        preferDisplayUrl: true,
+      }
+    } as FieldValueDirectAnswerType;
+    render(<FieldValueDirectAnswer result={result}/>);
+    expect(screen.getByRole('link', { name: '[preferUrl]' }))
+      .toHaveAttribute('href', '[url]');
+  });
+
+  it('contains proper url href for field type "Phone"', () => {
+    const result = {
+      ...fieldValueDAResult,
+      fieldType: BuiltInFieldType.Phone,
+      value: '123-456-7890'
+    } as FieldValueDirectAnswerType;
+    render(<FieldValueDirectAnswer result={result}/>);
+    expect(screen.getByRole('link', { name: '123-456-7890' }))
+      .toHaveAttribute('href', 'tel:123-456-7890');
+  });
+
+  it('contains proper url href for field type "Email"', () => {
+    const result = {
+      ...fieldValueDAResult,
+      fieldType: BuiltInFieldType.Email,
+      value: [
+        'email1@yext.com',
+        'email2@yext.com'
+      ]
+    } as FieldValueDirectAnswerType;
+    render(<FieldValueDirectAnswer result={result}/>);
+    expect(screen.getByRole('link', { name: 'email1@yext.com' }))
+      .toHaveAttribute('href', 'mailto:email1@yext.com');
+    expect(screen.getByRole('link', { name: 'email2@yext.com' }))
+      .toHaveAttribute('href', 'mailto:email2@yext.com');
+  });
+
+  it('displays the preferred address for field type "Address"', () => {
+    const extraDescription = 'This is the preferred address to display';
+    const address: Address = {
+      line1: '61 Ninth Avenue',
+      line2: '14th Floor',
+      city: 'New York',
+      region: 'NY',
+      postalCode: '10011',
+      countryCode: 'NY',
+      extraDescription
+    };
+    const result = {
+      ...fieldValueDAResult,
+      fieldType: BuiltInFieldType.Address,
+      value: address
+    } as FieldValueDirectAnswerType;
+    render(<FieldValueDirectAnswer result={result}/>);
+    expect(screen.getByText(extraDescription)).toBeDefined();
+  });
+
+  //TODO: test for rich text
+});


### PR DESCRIPTION
Added FieldValueDirectAnswer to handle all the built in field types for field value direct answer. Note, we currently do not support internationalization so addresses will be written as if they are US addresses.

in nidhi's PR for featured snippet direct answer, she will implement the logic to handle rich text field type using react-markdown library. So, the switch case for rich_text in FieldValueDirectAnswer will be updated once that is done. Along with the tests for rich_text.

J=SLAP-2332
TEST=auto

added storybook and jest tests for the different field types in field value direct answer