### PR TITLE
Fix TS error: `React refers to a UMD global` error

### DIFF
--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    "components"
+  ]
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "lib/commonjs"

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "esnext",
     "outDir": "lib/esm"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,5 @@
   },
   "include": [
     "src"
-  ],
-  "exclude": [
-    "src/**/*.test.*"
   ]
 }


### PR DESCRIPTION
This PR aim to resolve these errors in src/ and tests/component folder:
<img width="836" alt="Screen Shot 2022-08-26 at 3 44 10 PM" src="https://user-images.githubusercontent.com/36055303/186979930-6cc824bb-1c33-4802-b49f-b6ae68417050.png">

This is usually resolve by having a tsconfig.json file with "jsx": "react-jsx" config option in it. However, TS in the development environment (VSCode in this case) is not recognizing the top level name file tsconfig.base.json. (threads on this issue: [[1](https://github.com/microsoft/vscode/issues/12463)][[2](https://github.com/microsoft/TypeScript/issues/11224)])

This pr rename tsconfig.base.json => tsconfig.json that will apply to src folder. As well as adding another tsconfig.json which extends the top level tsconfig.json file but point to tests/components folder.

Note: there's a decent amount of errors now that tsconfig is apply to tests/components folder. Will resolve in future item/pr.

J=SLAP-
TEST=manual

See that those errors no longer appear in src and tests folder