### PR TITLE
Further updates to account for changes in `SearchHeadlessProvider`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Once the library and its peer dependencies are installed, the components can be 
 ```tsx
 import { SearchHeadlessProvider } from '@yext/search-headless-react';
 import { SearchBar, UniversalResults } from '@yext/search-ui-react';
+import { v4 as uuidv4 } from 'uuid';
 
 const config = {
   apiKey: '<apiKey>',
@@ -50,7 +51,7 @@ const searcher = provideHeadless(config);
 searcher.setSessionTrackingEnabled(true);
 let sessionId = window.sessionStorage.getItem('sessionId');
 if (!sessionId) {
-  sessionId = 'newUUID';
+  sessionId = uuidv4();
   window.sessionStorage.setItem('sessionId', sessionId);
 }
 searcher.setSessionId(sessionId);

--- a/README.md
+++ b/README.md
@@ -45,9 +45,19 @@ const config = {
   experienceVersion: 'PRODUCTION',
 }
 
+const searcher = provideHeadless(config);
+
+searcher.setSessionTrackingEnabled(true);
+let sessionId = window.sessionStorage.getItem('sessionId');
+if (!sessionId) {
+  sessionId = 'newUUID';
+  window.sessionStorage.setItem('sessionId', sessionId);
+}
+searcher.setSessionId(sessionId);
+
 function App() {
   return (
-    <SearchHeadlessProvider {...config}>
+    <SearchHeadlessProvider searcher={searcher}>
       <SearchBar />
       <UniversalResults />
     </SearchHeadlessProvider>

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -12,7 +12,8 @@
         "@yext/search-ui-react": "file:..",
         "react": "file:../node_modules/react",
         "react-dom": "file:../node_modules/react-dom",
-        "react-router-dom": "^6.2.2"
+        "react-router-dom": "^6.2.2",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@types/node": "^16.11.26",
@@ -27,7 +28,7 @@
     },
     "..": {
       "name": "@yext/search-ui-react",
-      "version": "1.0.0-beta.298",
+      "version": "1.0.0-alpha.301",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@microsoft/api-documenter": "^7.15.3",
@@ -72,7 +73,7 @@
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/eslint-config-slapshot": "^0.5.0",
-        "@yext/search-headless-react": "2.0.0-beta.154",
+        "@yext/search-headless-react": "2.0.0-alpha.158",
         "axe-playwright": "^1.1.11",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",
@@ -90,7 +91,7 @@
         "typescript": "~4.4.3"
       },
       "peerDependencies": {
-        "@yext/search-headless-react": "2.0.0-beta.154",
+        "@yext/search-headless-react": "2.0.0-alpha.158",
         "react": "^16.14 || ^17 || ^18"
       }
     },
@@ -30314,6 +30315,15 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -31369,10 +31379,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -35317,7 +35326,7 @@
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/analytics": "^0.2.0-beta.3",
         "@yext/eslint-config-slapshot": "^0.5.0",
-        "@yext/search-headless-react": "2.0.0-beta.154",
+        "@yext/search-headless-react": "2.0.0-alpha.158",
         "axe-playwright": "^1.1.11",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.3",
@@ -59066,6 +59075,14 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "source-list-map": {
@@ -59860,10 +59877,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/test-site/package.json
+++ b/test-site/package.json
@@ -7,7 +7,8 @@
     "@yext/search-ui-react": "file:..",
     "react": "file:../node_modules/react",
     "react-dom": "file:../node_modules/react-dom",
-    "react-router-dom": "^6.2.2"
+    "react-router-dom": "^6.2.2",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/node": "^16.11.26",

--- a/test-site/src/App.tsx
+++ b/test-site/src/App.tsx
@@ -9,11 +9,14 @@ import {
   Routes,
 } from 'react-router-dom';
 import { AnalyticsProvider } from '@yext/search-ui-react';
+import acquireSessionId from './utils/acquireSessionId';
 import { config } from './config';
 
 const searcher = provideHeadless(config);
-searcher.setSessionTrackingEnabled(false);
 
+searcher.setSessionTrackingEnabled(true);
+const sessionId = acquireSessionId();
+sessionId && searcher.setSessionId(sessionId);
 
 function App() {
   return (

--- a/test-site/src/utils/acquireSessionId.ts
+++ b/test-site/src/utils/acquireSessionId.ts
@@ -1,0 +1,22 @@
+import { v4 as uuidv4 } from 'uuid';
+/**
+ * Retrieves session id from local storage, or generates a new uuid to use as session id.
+ * The new id is then stored in local storage. Returns null if the sessionStorage API is
+ * unavailable. (e.g. The function is running on the server for SSR).
+ */
+export default function acquireSessionId(): string | null {
+  if (typeof(window) === 'undefined') {
+    return null;
+  }
+  try {
+    let sessionId = window.sessionStorage.getItem('sessionId');
+    if (!sessionId) {
+      sessionId = uuidv4();
+      window.sessionStorage.setItem('sessionId', sessionId);
+    }
+    return sessionId;
+  } catch (err) {
+    console.warn('Unable to use browser sessionStorage for sessionId.\n', err);
+    return null;
+  }
+}


### PR DESCRIPTION
The README was updated to reflect the fact that `SearchHeadlessProvider` now takes in a Headless instance. The README also shows someone how to handle acquisition of a session tracking ID. I added session tracking logic to the test-site as well as a further reference.

TEST=auto

Ensured that all unit and WCAG tests passed locally.