### PR TITLE
update readme "Getting Started" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Once the library and its peer dependencies are installed, our React Components s
 
 ```tsx
 import { provideHeadless, SearchHeadlessProvider } from '@yext/search-headless-react';
-import { SearchBar, UniversalResults } from '@yext/search-ui-react';
+import { SearchBar, UniversalResults, VerticalConfigMap } from '@yext/search-ui-react';
 import { v4 as uuidv4 } from 'uuid';
 
 const config = {
@@ -56,15 +56,17 @@ if (!sessionId) {
 }
 searcher.setSessionId(sessionId);
 
+const verticalConfigMap: VerticalConfigMap = {
+  help_articles: {
+    label: "Help Articles"
+  }
+}
+
 function App() {
   return (
     <SearchHeadlessProvider searcher={searcher}>
       <SearchBar />
-      <UniversalResults verticalConfigMap={{
-        help_articles: {
-          label: "Help Articles"
-          }
-      }}/>
+      <UniversalResults verticalConfigMap={verticalConfigMap}/>
     </SearchHeadlessProvider>
   );
 }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npx install-peerdeps @yext/search-ui-react
 ```
 The command will work with Yarn so long as NPM 6+ is installed on the machine.
 
-Once the library and its peer dependencies are installed, the components can be rendered using React by placing them inside the `SearchHeadlessProvider`. `SearchHeadlessProvider` requires a `SearchHeadless` instance, which is created using `provideHeadless(...)` with the appropriate credentials:
+Once the library and its peer dependencies are installed, our React Components should be nested inside the `SearchHeadlessProvider`. `SearchHeadlessProvider` requires a `SearchHeadless` instance, which is created using `provideHeadless(...)` with the appropriate credentials:
 
 ```tsx
 import { provideHeadless, SearchHeadlessProvider } from '@yext/search-headless-react';

--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ npx install-peerdeps @yext/search-ui-react
 ```
 The command will work with Yarn so long as NPM 6+ is installed on the machine.
 
-Once the library and its peer dependencies are installed, the components can be rendered using React by placing them inside the `SearchHeadlessProvider` with the appropriate credentials:
+Once the library and its peer dependencies are installed, the components can be rendered using React by placing them inside the `SearchHeadlessProvider`. `SearchHeadlessProvider` requires a `SearchHeadless` instance, which is created
+using `provideHeadless(...)` with the appropriate credentials:
 
 ```tsx
-import { SearchHeadlessProvider } from '@yext/search-headless-react';
+import { provideHeadless, SearchHeadlessProvider } from '@yext/search-headless-react';
 import { SearchBar, UniversalResults } from '@yext/search-ui-react';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -60,7 +61,11 @@ function App() {
   return (
     <SearchHeadlessProvider searcher={searcher}>
       <SearchBar />
-      <UniversalResults />
+      <UniversalResults verticalConfigMap={{
+        help_articles: {
+          label: "Help Articles"
+          }
+      }}/>
     </SearchHeadlessProvider>
   );
 }

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ npx install-peerdeps @yext/search-ui-react
 ```
 The command will work with Yarn so long as NPM 6+ is installed on the machine.
 
-Once the library and its peer dependencies are installed, the components can be rendered using React by placing them inside the `SearchHeadlessProvider`. `SearchHeadlessProvider` requires a `SearchHeadless` instance, which is created
-using `provideHeadless(...)` with the appropriate credentials:
+Once the library and its peer dependencies are installed, the components can be rendered using React by placing them inside the `SearchHeadlessProvider`. `SearchHeadlessProvider` requires a `SearchHeadless` instance, which is created using `provideHeadless(...)` with the appropriate credentials:
 
 ```tsx
 import { provideHeadless, SearchHeadlessProvider } from '@yext/search-headless-react';


### PR DESCRIPTION
update readme wording now that `SearchHeadlessProvider` requires a `SearchHeadless` instance instead of directly passing in the credentials. Also include small changes such that the code sample works out of the box.

TEST=manual

copy and pasted the code sample to test-site App.tsx using the actual credentials, See that it works as expected.