### PR TITLE
console warn for no render markdown support

### DIFF
--- a/src/components/FeaturedSnippetDirectAnswer.tsx
+++ b/src/components/FeaturedSnippetDirectAnswer.tsx
@@ -37,7 +37,7 @@ export function FeaturedSnippetDirectAnswer({
   const answer = result.fieldType === 'multi_line_text' && result.value;
   // TODO: SLAP-2340, update rich text snippets to convert the markdown
   if (result.fieldType === 'rich_text') {
-    console.warn('Rendering markdown for rich text direct answer is currently not supported.');
+    console.warn('Rendering markdown for rich text direct answer is currently not supported. Displaying the unrendered markdown string as is.');
   }
   const snippet = renderHighlightedValue(result.snippet, { highlighted: cssClasses.highlighted });
   const link = result.relatedResult.link || result.relatedResult.rawData.landingPageUrl as string;

--- a/src/components/FeaturedSnippetDirectAnswer.tsx
+++ b/src/components/FeaturedSnippetDirectAnswer.tsx
@@ -36,6 +36,9 @@ export function FeaturedSnippetDirectAnswer({
 }: FeaturedSnippetDirectAnswerProps): JSX.Element {
   const answer = result.fieldType === 'multi_line_text' && result.value;
   // TODO: SLAP-2340, update rich text snippets to convert the markdown
+  if (result.fieldType === 'rich_text') {
+    console.warn('Rendering markdown for rich text direct answer is currently not supported.');
+  }
   const snippet = renderHighlightedValue(result.snippet, { highlighted: cssClasses.highlighted });
   const link = result.relatedResult.link || result.relatedResult.rawData.landingPageUrl as string;
   const name = result.relatedResult.name;

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -106,7 +106,7 @@ function getResultContent(
       return getAddressJsxElement(result.value);
     case BuiltInFieldType.RichText:
       //TODO: SLAP-2340
-      console.warn('Rendering markdown for rich text direct answer is currently not supported. Displaying the unrendered markdown string as is.');
+      console.warn('Rendering markdown for rich text direct answer is currently not supported. Displaying the unrendered markdown string(s) as is.');
       return Array.isArray(result.value)
         ? getListJsxElement(result.value, val => getTextJsxElement(val))
         : getTextJsxElement(result.value);

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -105,7 +105,7 @@ function getResultContent(
     case BuiltInFieldType.Address:
       return getAddressJsxElement(result.value);
     case BuiltInFieldType.RichText:
-      console.warn('Rendering markdown for rich text direct answer is currently not supported.');
+      console.warn('Rendering markdown for rich text direct answer is currently not supported. Displaying the unrendered markdown string as is.');
       return <div>{JSON.stringify(result.value)}</div>; //TODO: SLAP-2340
     case BuiltInFieldType.Hours:
       return <div>{JSON.stringify(result.value)}</div>;

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -105,8 +105,11 @@ function getResultContent(
     case BuiltInFieldType.Address:
       return getAddressJsxElement(result.value);
     case BuiltInFieldType.RichText:
+      //TODO: SLAP-2340
       console.warn('Rendering markdown for rich text direct answer is currently not supported. Displaying the unrendered markdown string as is.');
-      return <div>{JSON.stringify(result.value)}</div>; //TODO: SLAP-2340
+      return Array.isArray(result.value)
+        ? getListJsxElement(result.value, val => getTextJsxElement(val))
+        : getTextJsxElement(result.value);
     case BuiltInFieldType.Hours:
       return <div>{JSON.stringify(result.value)}</div>;
     case 'unknown':

--- a/src/components/FieldValueDirectAnswer.tsx
+++ b/src/components/FieldValueDirectAnswer.tsx
@@ -105,9 +105,10 @@ function getResultContent(
     case BuiltInFieldType.Address:
       return getAddressJsxElement(result.value);
     case BuiltInFieldType.RichText:
-      return <div>{result.value}</div>; //TODO: SLAP-2340
+      console.warn('Rendering markdown for rich text direct answer is currently not supported.');
+      return <div>{JSON.stringify(result.value)}</div>; //TODO: SLAP-2340
     case BuiltInFieldType.Hours:
-      return <div>{result.value}</div>;
+      return <div>{JSON.stringify(result.value)}</div>;
     case 'unknown':
       return <UnknownFieldTypeDisplay result={result}/>;
     default:


### PR DESCRIPTION
Per product's request: "good with displaying rich text direct answer as unrendered markdown for now, with the accompanying console warning." This pr added console warn in field value and featured snippet direct answer dealing with rich text field type. Also use JSON.stringify() on result of rich text and hours to avoid potential React errors such as `Objects are not valid as a React child`
