### PR TITLE
Run tests on react v18

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,6 +6,14 @@ name: Run Tests
 on: [push, pull_request]
 
 jobs:
+  call_run_tests-react-18:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
+    with:
+      build_script: |
+        npm i -D react@18 react-dom@18
+        npm run build
+      node_matrix: '["14.x", "16.x", "18.x"]'
+
   call_run_tests-react-17:
     uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
     with:


### PR DESCRIPTION
Update the run-tests workflow to have tests run on v18 of react, as well as v17 and v16.4 that it currently does.

J=SLAP-2125
TEST=manual

See that the tests workflow runs on react 16.14, 17, and 18 on this PR.