### PR TITLE
Add react-dom as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,8 @@
       },
       "peerDependencies": {
         "@yext/search-headless-react": "^2.0.0",
-        "react": "^16.14 || ^17 || ^18"
+        "react": "^16.14 || ^17 || ^18",
+        "react-dom": "^16.14 || ^17 || ^18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
   },
   "peerDependencies": {
     "@yext/search-headless-react": "^2.0.0",
-    "react": "^16.14 || ^17 || ^18"
+    "react": "^16.14 || ^17 || ^18",
+    "react-dom": "^16.14 || ^17 || ^18"
   },
   "jest": {
     "bail": 0,

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -95,7 +95,8 @@
       },
       "peerDependencies": {
         "@yext/search-headless-react": "^2.0.0",
-        "react": "^16.14 || ^17 || ^18"
+        "react": "^16.14 || ^17 || ^18",
+        "react-dom": "^16.14 || ^17 || ^18"
       }
     },
     "../node_modules/@ampproject/remapping": {


### PR DESCRIPTION
Add react-dom as a peer dependency as it's now use in Mapbox component.

Note that, ReactDOM.render is deprecated in React 18, which now have a new client render function `createRoot`. For now, a warning will display in console informing user that the app will behave as if it’s running React 17 until the code switch to the new API. A new item will be created to address this issue.

TEST=manual

`npm pack` the component lib. Created a new React app using react 17/18, see that react-dom is installed as peer dep (automatically install with npm >=7) and mapbox component is display as expected (there's a warning in React 18).