### PR TITLE
Fix React SSR hydration ID mismatch error

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -30,6 +30,10 @@ module.exports = {
   framework: '@storybook/react',
   staticDirs: ['./public'],
   webpackFinal: async (config) => {
+    //use commonjs entry point for "@reach" packages
+    config.resolve.alias['@reach/auto-id'] = require.resolve('@reach/auto-id');
+    config.resolve.alias['@reach/utils'] = require.resolve('@reach/utils');
+
     config.resolve.alias['./SearchCore'] = require.resolve('../tests/__fixtures__/core/SearchCore.ts');
     config.resolve.alias['../utils/location-operations'] = require.resolve('../tests/__fixtures__/utils/location-operations.ts');
     return config;

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -194,9 +194,39 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
+The following NPM packages may be included in this product:
+
+ - @reach/auto-id@0.18.0
+ - @reach/utils@0.18.0
+
+These packages each contain the following license and notice below:
+
+The MIT License (MIT)
+
+Copyright (c) 2018-2022, React Training LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----------
+
 The following NPM package may be included in this product:
 
- - @react-aria/ssr@3.1.0
+ - @react-aria/ssr@3.3.0
 
 This package contains the following license and notice below:
 
@@ -4910,24 +4940,6 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
-
------------
-
-The following NPM package may be included in this product:
-
- - uuid@9.0.0
-
-This package contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) 2010-2020 Robert Kieffer and other contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@microsoft/api-documenter": "^7.15.3",
         "@microsoft/api-extractor": "^7.19.4",
+        "@reach/auto-id": "^0.18.0",
         "@restart/ui": "^1.0.1",
         "@tailwindcss/forms": "^0.5.0",
         "@yext/analytics": "^0.2.0-beta.3",
@@ -19,8 +20,7 @@
         "react-collapsed": "^3.3.0",
         "recent-searches": "^1.0.5",
         "tailwind-merge": "^1.3.0",
-        "use-isomorphic-layout-effect": "^1.1.2",
-        "uuid": "^9.0.0"
+        "use-isomorphic-layout-effect": "^1.1.2"
       },
       "devDependencies": {
         "@babel/core": "^7.17.5",
@@ -47,7 +47,6 @@
         "@types/jest": "^29.1.0",
         "@types/lodash": "^4.14.180",
         "@types/react": "^17.0.38",
-        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/eslint-config-slapshot": "^0.5.0",
@@ -5421,14 +5420,36 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reach/auto-id": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.18.0.tgz",
+      "integrity": "sha512-XwY1IwhM7mkHZFghhjiqjQ6dstbOdpbFLdggeke75u8/8icT8uEHLbovFUgzKjy9qPvYwZIB87rLiR8WdtOXCg==",
+      "dependencies": {
+        "@reach/utils": "0.18.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/utils": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.18.0.tgz",
+      "integrity": "sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==",
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
     "node_modules/@react-aria/ssr": {
-      "version": "3.1.0",
-      "integrity": "sha512-RxqQKmE8sO7TGdrcSlHTcVzMP450hqowtBSd2bBS9oPlcokVkaGq28c3Rwa8ty5ctw4EBCjXqjP7xdcKMGDzug==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.3.0.tgz",
+      "integrity": "sha512-yNqUDuOVZIUGP81R87BJVi/ZUZp/nYOBXbPsRe7oltJOfErQZD+UezMpw4vM2KRz18cURffvmC8tJ6JTeyDtaQ==",
       "dependencies": {
         "@babel/runtime": "^7.6.2"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -10063,11 +10084,6 @@
     "node_modules/@types/unist": {
       "version": "2.0.6",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
-      "dev": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "node_modules/@types/wait-on": {
@@ -31596,14 +31612,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/uuid-browser": {
       "version": "3.1.0",
       "integrity": "sha1-DwWkCu90+eWVHiDvv0SxGHHlZBA=",
@@ -36943,9 +36951,24 @@
       "version": "2.11.2",
       "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
     },
+    "@reach/auto-id": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.18.0.tgz",
+      "integrity": "sha512-XwY1IwhM7mkHZFghhjiqjQ6dstbOdpbFLdggeke75u8/8icT8uEHLbovFUgzKjy9qPvYwZIB87rLiR8WdtOXCg==",
+      "requires": {
+        "@reach/utils": "0.18.0"
+      }
+    },
+    "@reach/utils": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.18.0.tgz",
+      "integrity": "sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==",
+      "requires": {}
+    },
     "@react-aria/ssr": {
-      "version": "3.1.0",
-      "integrity": "sha512-RxqQKmE8sO7TGdrcSlHTcVzMP450hqowtBSd2bBS9oPlcokVkaGq28c3Rwa8ty5ctw4EBCjXqjP7xdcKMGDzug==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.3.0.tgz",
+      "integrity": "sha512-yNqUDuOVZIUGP81R87BJVi/ZUZp/nYOBXbPsRe7oltJOfErQZD+UezMpw4vM2KRz18cURffvmC8tJ6JTeyDtaQ==",
       "requires": {
         "@babel/runtime": "^7.6.2"
       }
@@ -40378,11 +40401,6 @@
     "@types/unist": {
       "version": "2.0.6",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
-      "dev": true
-    },
-    "@types/uuid": {
-      "version": "8.3.4",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "@types/wait-on": {
@@ -56943,11 +56961,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
-    },
-    "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "uuid-browser": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@types/jest": "^29.1.0",
     "@types/lodash": "^4.14.180",
     "@types/react": "^17.0.38",
-    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
     "@yext/eslint-config-slapshot": "^0.5.0",
@@ -136,6 +135,7 @@
   "dependencies": {
     "@microsoft/api-documenter": "^7.15.3",
     "@microsoft/api-extractor": "^7.19.4",
+    "@reach/auto-id": "^0.18.0",
     "@restart/ui": "^1.0.1",
     "@tailwindcss/forms": "^0.5.0",
     "@yext/analytics": "^0.2.0-beta.3",
@@ -144,8 +144,7 @@
     "react-collapsed": "^3.3.0",
     "recent-searches": "^1.0.5",
     "tailwind-merge": "^1.3.0",
-    "use-isomorphic-layout-effect": "^1.1.2",
-    "uuid": "^9.0.0"
+    "use-isomorphic-layout-effect": "^1.1.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "THIRD-PARTY-NOTICES"
   ],
   "scripts": {
-    "build": "rm -rf lib/** && npm run build:js && npm run build:css && npm run api-extractor && npm run generate-docs",
+    "build": "rm -rf lib/** && npm run build:js && npm run build:css && npm run api-extractor && npm run generate-docs && npm run generate-notices",
     "build:js": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
     "build:css": "tailwindcss -o ./lib/bundle.css --minify -c tailwind.config.cjs",
     "dev": "tsc --watch -p tsconfig.esm.json",

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -3,11 +3,11 @@ import { DropdownContext, DropdownContextType } from './DropdownContext';
 import { InputContext, InputContextType } from './InputContext';
 import useRootClose from '@restart/ui/useRootClose';
 import { FocusContext, FocusContextType } from './FocusContext';
-import { v4 as uuid } from 'uuid';
 import { ScreenReader } from '../ScreenReader';
 import { recursivelyMapChildren } from '../utils/recursivelyMapChildren';
 import { DropdownItem, DropdownItemProps, DropdownItemWithIndex } from './DropdownItem';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
+import { useId } from '@reach/auto-id';
 
 interface DropdownItemData {
   value: string,
@@ -52,7 +52,7 @@ export function Dropdown(props: PropsWithChildren<DropdownProps>): JSX.Element {
   } = props;
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const screenReaderUUID: string = useMemo(() => uuid(), []);
+  const screenReaderUUID = useId();
   const [screenReaderKey, setScreenReaderKey] = useState<number>(0);
   const [hasTyped, setHasTyped] = useState<boolean>(false);
   const [childrenWithDropdownItemsTransformed, items] = useMemo(() => {
@@ -242,7 +242,7 @@ function useDropdownContextInstance(
   value: string,
   index: number,
   focusedItemData: Record<string, unknown> | undefined,
-  screenReaderUUID: string,
+  screenReaderUUID: string | undefined,
   setHasTyped: (hasTyped: boolean) => void,
   onToggle?: (
     isActive: boolean,

--- a/src/components/Filters/CheckboxOption.tsx
+++ b/src/components/Filters/CheckboxOption.tsx
@@ -1,12 +1,11 @@
 import { FieldValueFilter, Matcher, NumberRangeValue } from '@yext/search-headless-react';
 import { useCallback, useEffect, useMemo } from 'react';
-import { v4 as uuid } from 'uuid';
 import { useFiltersContext } from './FiltersContext';
 import { useFilterGroupContext } from './FilterGroupContext';
 import { useComposedCssClasses } from '../../hooks/useComposedCssClasses';
 import { findSelectableFieldValueFilter } from '../../utils/filterutils';
 import classNames from 'classnames';
-
+import { useId } from '@reach/auto-id';
 /**
  * The configuration data for a field value filter option.
  *
@@ -79,7 +78,7 @@ export function CheckboxOption(props: CheckboxOptionProps): JSX.Element | null {
     resultsCount
   } = props;
   const cssClasses = useComposedCssClasses(builtInCssClasses, props.customCssClasses);
-  const optionId = useMemo(() => uuid(), []);
+  const optionId = useId();
   const { selectFilter, filters, applyFilters } = useFiltersContext();
 
   const handleClick = useCallback((checked: boolean) => {

--- a/src/components/ScreenReader.tsx
+++ b/src/components/ScreenReader.tsx
@@ -1,5 +1,5 @@
 interface Props {
-  instructionsId: string,
+  instructionsId?: string,
   instructions: string,
   announcementKey: number,
   announcementText: string

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -19,6 +19,7 @@
         "@types/node": "^16.11.26",
         "@types/react": "^17.0.42",
         "@types/react-dom": "^17.0.14",
+        "@types/uuid": "^8.3.4",
         "autoprefixer": "^10.4.4",
         "postcss": "^8.4.12",
         "react-scripts": "5.0.0",
@@ -33,6 +34,7 @@
       "dependencies": {
         "@microsoft/api-documenter": "^7.15.3",
         "@microsoft/api-extractor": "^7.19.4",
+        "@reach/auto-id": "^0.18.0",
         "@restart/ui": "^1.0.1",
         "@tailwindcss/forms": "^0.5.0",
         "@yext/analytics": "^0.2.0-beta.3",
@@ -41,8 +43,7 @@
         "react-collapsed": "^3.3.0",
         "recent-searches": "^1.0.5",
         "tailwind-merge": "^1.3.0",
-        "use-isomorphic-layout-effect": "^1.1.2",
-        "uuid": "^9.0.0"
+        "use-isomorphic-layout-effect": "^1.1.2"
       },
       "devDependencies": {
         "@babel/core": "^7.17.5",
@@ -51,6 +52,7 @@
         "@babel/preset-typescript": "^7.14.5",
         "@percy/cli": "^1.8.0",
         "@percy/storybook": "^4.3.3",
+        "@reduxjs/toolkit": "^1.8.6",
         "@storybook/addon-a11y": "^6.5.10",
         "@storybook/addon-actions": "^6.5.10",
         "@storybook/addon-coverage": "^0.0.2",
@@ -68,7 +70,6 @@
         "@types/jest": "^29.1.0",
         "@types/lodash": "^4.14.180",
         "@types/react": "^17.0.38",
-        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/eslint-config-slapshot": "^0.5.0",
@@ -4322,10 +4323,6 @@
     },
     "../node_modules/@types/unist": {
       "version": "2.0.6",
-      "dev": true
-    },
-    "../node_modules/@types/uuid": {
-      "version": "8.3.4",
       "dev": true
     },
     "../node_modules/@types/warning": {
@@ -14466,9 +14463,6 @@
       "version": "1.0.1",
       "dev": true
     },
-    "../node_modules/uuid": {
-      "version": "8.3.2"
-    },
     "../node_modules/uuid-browser": {
       "version": "3.1.0",
       "dev": true
@@ -19070,6 +19064,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -35069,6 +35069,12 @@
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
+    },
     "@types/ws": {
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
@@ -35384,6 +35390,8 @@
         "@microsoft/api-extractor": "^7.19.4",
         "@percy/cli": "^1.8.0",
         "@percy/storybook": "^4.3.3",
+        "@reach/auto-id": "^0.18.0",
+        "@reduxjs/toolkit": "^1.8.6",
         "@restart/ui": "^1.0.1",
         "@storybook/addon-a11y": "^6.5.10",
         "@storybook/addon-actions": "^6.5.10",
@@ -35403,7 +35411,6 @@
         "@types/jest": "^29.1.0",
         "@types/lodash": "^4.14.180",
         "@types/react": "^17.0.38",
-        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/analytics": "^0.2.0-beta.3",
@@ -35430,8 +35437,7 @@
         "tailwind-merge": "^1.3.0",
         "tailwindcss": "^3.0.23",
         "typescript": "~4.5.5",
-        "use-isomorphic-layout-effect": "^1.1.2",
-        "uuid": "^9.0.0"
+        "use-isomorphic-layout-effect": "^1.1.2"
       },
       "dependencies": {
         "@ampproject/remapping": {
@@ -39733,10 +39739,6 @@
         },
         "@types/unist": {
           "version": "2.0.6",
-          "dev": true
-        },
-        "@types/uuid": {
-          "version": "8.3.4",
           "dev": true
         },
         "@types/warning": {
@@ -50216,9 +50218,6 @@
         "utils-merge": {
           "version": "1.0.1",
           "dev": true
-        },
-        "uuid": {
-          "version": "8.3.2"
         },
         "uuid-browser": {
           "version": "3.1.0",

--- a/test-site/package.json
+++ b/test-site/package.json
@@ -14,6 +14,7 @@
     "@types/node": "^16.11.26",
     "@types/react": "^17.0.42",
     "@types/react-dom": "^17.0.14",
+    "@types/uuid": "^8.3.4",
     "autoprefixer": "^10.4.4",
     "postcss": "^8.4.12",
     "react-scripts": "5.0.0",

--- a/tests/__setup__/responses/universal-query.tsx
+++ b/tests/__setup__/responses/universal-query.tsx
@@ -1,8 +1,6 @@
-import { v4 as uuid } from 'uuid';
-
 export const universalQueryResponseWithFilters = {
   meta: {
-    uuid: uuid(),
+    uuid: '123',
     errors: []
   },
   response: {
@@ -276,7 +274,7 @@ export const universalQueryResponseWithFilters = {
 
 export const universalQueryResponse = {
   meta: {
-    uuid: uuid(),
+    uuid: '123',
     errors: []
   },
   response: {

--- a/tests/__setup__/responses/vertical-query.ts
+++ b/tests/__setup__/responses/vertical-query.ts
@@ -1,5 +1,3 @@
-import { v4 as uuid } from 'uuid';
-
 export const verticalQueryResponseWithNlpFilters = {
   meta: {
     uuid: '017cb8d9-2f76-1f19-5bb9-a2f931650de2',
@@ -576,12 +574,12 @@ export const verticalQueryResponseWithNlpFilters = {
 
 export const verticalQueryResponse = {
   meta: {
-    uuid: uuid(),
+    uuid: '123',
     errors: []
   },
   response: {
     businessId: 3575590,
-    queryId: uuid(),
+    queryId: '123',
     resultsCount: 1,
     results: [
       {

--- a/tests/components/Dropdown.test.tsx
+++ b/tests/components/Dropdown.test.tsx
@@ -4,8 +4,25 @@ import { Dropdown, DropdownProps } from '../../src/components/Dropdown/Dropdown'
 import { DropdownInput } from '../../src/components/Dropdown/DropdownInput';
 import { DropdownMenu } from '../../src/components/Dropdown/DropdownMenu';
 import { DropdownItem } from '../../src/components/Dropdown/DropdownItem';
+import { testSSR } from '../ssr/utils';
 
 describe('Dropdown', () => {
+  it('renders identical content between the server and the client.', () => {
+    function App(): JSX.Element {
+      return (
+        <Dropdown screenReaderText='screen reader text here'>
+          <DropdownInput />
+          <DropdownMenu>
+            <DropdownItem value='item1'>
+              item1
+            </DropdownItem>
+          </DropdownMenu>
+        </Dropdown>
+      );
+    }
+    testSSR(App);
+  });
+
   it('can toggle hide/display', () => {
     const mockedOnToggleFn = jest.fn();
     const dropdownProps: DropdownProps = {
@@ -28,7 +45,7 @@ describe('Dropdown', () => {
     // hidden by default
     expect(screen.queryByText('item1')).toBeNull();
 
-    // display when click into dropdown input
+    //display when click into dropdown input
     userEvent.click(screen.getByRole('textbox'));
     expect(screen.getByText('item1')).toBeDefined();
     expect(mockedOnToggleFn).toBeCalledWith(true, '', '', -1, undefined);
@@ -344,3 +361,8 @@ describe('Always Select Option', () => {
     expect(mockedOnSelectFn).toBeCalledTimes(0);
   });
 });
+
+// expect(consoleErrorSpy).toBeCalledWith(
+//   expect.stringMatching(/^Warning: Prop `.+` did not match. Server: ".+" Client: ".+".+/s)
+// );
+

--- a/tests/components/Dropdown.test.tsx
+++ b/tests/components/Dropdown.test.tsx
@@ -8,19 +8,16 @@ import { testSSR } from '../ssr/utils';
 
 describe('Dropdown', () => {
   it('renders identical content between the server and the client.', () => {
-    function App(): JSX.Element {
-      return (
-        <Dropdown screenReaderText='screen reader text here'>
-          <DropdownInput />
-          <DropdownMenu>
-            <DropdownItem value='item1'>
-              item1
-            </DropdownItem>
-          </DropdownMenu>
-        </Dropdown>
-      );
-    }
-    testSSR(App);
+    testSSR(
+      <Dropdown screenReaderText='screen reader text here'>
+        <DropdownInput />
+        <DropdownMenu>
+          <DropdownItem value='item1'>
+            item1
+          </DropdownItem>
+        </DropdownMenu>
+      </Dropdown>
+    );
   });
 
   it('can toggle hide/display', () => {

--- a/tests/components/Dropdown.test.tsx
+++ b/tests/components/Dropdown.test.tsx
@@ -45,7 +45,7 @@ describe('Dropdown', () => {
     // hidden by default
     expect(screen.queryByText('item1')).toBeNull();
 
-    //display when click into dropdown input
+    // display when click into dropdown input
     userEvent.click(screen.getByRole('textbox'));
     expect(screen.getByText('item1')).toBeDefined();
     expect(mockedOnToggleFn).toBeCalledWith(true, '', '', -1, undefined);
@@ -361,8 +361,3 @@ describe('Always Select Option', () => {
     expect(mockedOnSelectFn).toBeCalledTimes(0);
   });
 });
-
-// expect(consoleErrorSpy).toBeCalledWith(
-//   expect.stringMatching(/^Warning: Prop `.+` did not match. Server: ".+" Client: ".+".+/s)
-// );
-

--- a/tests/components/StaticFilters.test.tsx
+++ b/tests/components/StaticFilters.test.tsx
@@ -5,6 +5,7 @@ import { FilterOptionConfig } from '../../src/components/Filters';
 import userEvent from '@testing-library/user-event';
 import { StaticFilters } from '../../src/components';
 import { staticFilters, staticFiltersProps } from '../__fixtures__/data/filters';
+import { testSSR } from '../ssr/utils';
 
 const mockedState: Partial<State> = {
   filters: {
@@ -37,6 +38,10 @@ jest.mock('@yext/search-headless-react');
 describe('Static Filters', () => {
   beforeEach(() => {
     mockAnswersHooks({ mockedState, mockedActions, mockedUtils });
+  });
+
+  it('renders identical content between the server and the client.', () => {
+    testSSR(() => <StaticFilters {...staticFiltersProps} />);
   });
 
   it('Properly renders default, basic static filters', () => {

--- a/tests/components/StaticFilters.test.tsx
+++ b/tests/components/StaticFilters.test.tsx
@@ -41,7 +41,7 @@ describe('Static Filters', () => {
   });
 
   it('renders identical content between the server and the client.', () => {
-    testSSR(() => <StaticFilters {...staticFiltersProps} />);
+    testSSR(<StaticFilters {...staticFiltersProps} />);
   });
 
   it('Properly renders default, basic static filters', () => {

--- a/tests/ssr/utils.tsx
+++ b/tests/ssr/utils.tsx
@@ -1,11 +1,11 @@
 import { render } from '@testing-library/react';
 import { renderToString } from 'react-dom/server';
-import React from 'react';
+import { FunctionComponent } from 'react';
 
-const USE_LAYOUT_EFFECT_ERROR = 'useLayoutEffect does nothing on the server';
+const USE_LAYOUT_EFFECT_ERROR = /useLayoutEffect does nothing on the server/;
 const originalConsoleError = console.error.bind(console.error);
 
-export function testSSR(App: React.FunctionComponent) {
+export function testSSR(App: FunctionComponent) {
   const renderOnServer = () => renderToString(<App />);
   const container = document.body.appendChild(document.createElement('div'));
   const consoleErrorSpy = jest.spyOn(global.console, 'error')
@@ -17,7 +17,7 @@ export function testSSR(App: React.FunctionComponent) {
        * Suppress useLayoutEffect warnings here since the mock window in jest test
        * environment made the workaround with isomorphic-layout-effect ineffective.
        */
-      if (!msg.toString().includes(USE_LAYOUT_EFFECT_ERROR)) {
+      if (!msg.toString().match(USE_LAYOUT_EFFECT_ERROR)) {
         originalConsoleError(msg);
       }
     });

--- a/tests/ssr/utils.tsx
+++ b/tests/ssr/utils.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
+import React from 'react';
+
+const USE_LAYOUT_EFFECT_ERROR = 'useLayoutEffect does nothing on the server';
+const originalConsoleError = console.error.bind(console.error);
+
+export function testSSR(App: React.FunctionComponent) {
+  const renderOnServer = () => renderToString(<App />);
+  const container = document.body.appendChild(document.createElement('div'));
+  const consoleErrorSpy = jest.spyOn(global.console, 'error')
+    .mockImplementation((msg) => {
+      if (!msg.toString().includes(USE_LAYOUT_EFFECT_ERROR)) {
+        originalConsoleError(msg);
+      }
+    });
+
+  //server render components to static markup
+  container.innerHTML = renderOnServer();
+
+  //hydrate a container whose HTML contents were rendered by ReactDOMServer
+  render(<App />, { container, hydrate: true });
+  expect(consoleErrorSpy).not.toBeCalledWith(
+    expect.stringContaining('Warning: Prop `%s` did not match. Server: %s Client: %s%s'),
+    'id',
+    expect.anything(),
+    expect.anything(),
+    expect.anything()
+  );
+}

--- a/tests/ssr/utils.tsx
+++ b/tests/ssr/utils.tsx
@@ -1,12 +1,12 @@
 import { render } from '@testing-library/react';
 import { renderToString } from 'react-dom/server';
-import { FunctionComponent } from 'react';
+import { ReactElement } from 'react';
 
 const USE_LAYOUT_EFFECT_ERROR = /useLayoutEffect does nothing on the server/;
 const originalConsoleError = console.error.bind(console.error);
 
-export function testSSR(App: FunctionComponent) {
-  const renderOnServer = () => renderToString(<App />);
+export function testSSR(App: ReactElement) {
+  const renderOnServer = () => renderToString(App);
   const container = document.body.appendChild(document.createElement('div'));
   let unexpectedErrorCount = 0;
   jest.spyOn(global.console, 'error')
@@ -28,6 +28,6 @@ export function testSSR(App: FunctionComponent) {
   container.innerHTML = renderOnServer();
 
   // hydrate a container whose HTML contents were rendered by ReactDOMServer
-  render(<App />, { container, hydrate: true });
+  render(App, { container, hydrate: true });
   expect(unexpectedErrorCount).toEqual(0);
 }

--- a/tests/ssr/utils.tsx
+++ b/tests/ssr/utils.tsx
@@ -28,7 +28,7 @@ export function testSSR(App: FunctionComponent) {
   // hydrate a container whose HTML contents were rendered by ReactDOMServer
   render(<App />, { container, hydrate: true });
   expect(consoleErrorSpy).not.toBeCalledWith(
-    expect.stringContaining('Warning: Prop `%s` did not match. Server: %s Client: %s%s'),
+    'Warning: Prop `%s` did not match. Server: %s Client: %s%s',
     'id',
     expect.anything(),
     expect.anything(),

--- a/tests/ssr/utils.tsx
+++ b/tests/ssr/utils.tsx
@@ -10,15 +10,22 @@ export function testSSR(App: React.FunctionComponent) {
   const container = document.body.appendChild(document.createElement('div'));
   const consoleErrorSpy = jest.spyOn(global.console, 'error')
     .mockImplementation((msg) => {
+      /**
+       * Caveat of SSR: useEffect and useLayoutEffect hooks do not run when
+       * rendering on server.
+       *
+       * Suppress useLayoutEffect warnings here since the mock window in jest test
+       * environment made the workaround with isomorphic-layout-effect ineffective.
+       */
       if (!msg.toString().includes(USE_LAYOUT_EFFECT_ERROR)) {
         originalConsoleError(msg);
       }
     });
 
-  //server render components to static markup
+  // server render components to static markup
   container.innerHTML = renderOnServer();
 
-  //hydrate a container whose HTML contents were rendered by ReactDOMServer
+  // hydrate a container whose HTML contents were rendered by ReactDOMServer
   render(<App />, { container, hydrate: true });
   expect(consoleErrorSpy).not.toBeCalledWith(
     expect.stringContaining('Warning: Prop `%s` did not match. Server: %s Client: %s%s'),

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
   "include": [
     "components",
-    "hooks"
+    "hooks",
+    "ssr"
   ]
 }


### PR DESCRIPTION
This PR is to fix the errors `Warning: Prop "id" did not match. Server: "some-id". Client: "another-id"`, reported in https://yext.slack.com/archives/C032CKFARGS/p1664916209295449

React expects that the **rendered content is identical between the server and the client**. However, our usage of `uuid` means different id is generated from the HTML content generated through SSR vs the first render in client side during hydration process. This is a known issues in React SSR (issues in react repo[[1](https://github.com/facebook/react/issues/4000)][[2](https://github.com/facebook/react/issues/5867)][[3](https://github.com/facebook/react/issues/1137)]) and React released a new hook `useId` in React 18 to address it.

I found three potential solutions for React <18 to **generate unique but predictable id**, each with an external library we could use:
1) Use context to keep a counter in state, so counter is not shared across renders. This approach is implemented in [react-aria](https://www.npmjs.com/package/react-aria). When using SSR with React Aria, applications must be wrapped in an `SSRProvider` component to reset the count in server side to be zero for each fresh render. Multiple copies of React Aria is not supported so it would be a peer-dep
```
//in component lib (dropdown)
import { useId } from 'react-aria';
...
const screenReaderUUID: string = useId();

//in pageJS template using SSR
import { SSRProvider } from 'react-aria';
...
<SSRProvider>
    <TestComponent />
</SSRProvider>
```
2) use a global counter to increment on initial renders and expose a reset function for SSR side. This approach is implemented in [react-id-generator](https://www.npmjs.com/package/react-id-generator). There's a function `resetId` required to invoke from SSR side (such as in PageJS `serverRenderRoute` or somewhere in user's template page) to avoid mismatch during refresh, since browser generator will always restart from "1" but server's count will keep incrementing.

3) Don't use IDs at all on the server; patch after first render. This approach is implemented in [reach/auto-id.](https://www.npmjs.com/package/@reach/auto-id) ID returned as undefined/empty on the first render so server and client have the same markup during hydration process. After render, patch the components with an incremented ID (second render) in useLayoutEffect. (more info [here](https://github.com/reach/reach-ui/blob/dev/packages/auto-id/src/reach-auto-id.ts)) No changes needed outside of using `import { useId } from '@reach/auto-id';` in our component lib.

I decided to go with the last approach using `react/auto-id` because:
- requires no additional work / changes from user side (only in component lib)
- contain fallback implementation to React 18 `useId` if it's available
- avoid potential concurrent rendering problem (such as suspense boundaries)
- the main issue with this approach is that it causes a double render on any components with `useId`. However, since we (1) only update the ID attribute on DOM on second render, and (2) our components that uses `useId` already requires multiple renders to get setup, the performance is not greatly affected. I used Profiler in our test-site to measure performance, the number of renders and time spent for `SearchBar`, `StaticFilters`, and `FilterSearch` did not change as the dispatch from `useId` is grouped with other changes required in our components on second render. This is only needed for React <18

J=SLAP-2403
TEST=manual&auto

`npm pack` a build of the component lib with the new changes and tested SearchBar, FilterSearch, and StaticFilers:
- in the starter PageJS project (https://github.com/yext/pages-starter-react-locations) with React 17
- in another [yext-sites-starter](https://github.com/tmeyer2115/yext-sites-starter) repo with React 18 override

See that the warning about Prop `id` mismatched no longer appear in console

added new jest test for Dropdown and StaticFilter, see that test failed the previous usage of uuid, and passed with reach/auto-id. 