### PR TITLE
Create hot-fix v1.0.1. (#318)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-ui-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-ui-react",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@microsoft/api-documenter": "^7.15.3",
@@ -16,6 +16,7 @@
         "@tailwindcss/forms": "^0.5.0",
         "@yext/analytics": "^0.2.0-beta.3",
         "classnames": "^2.3.1",
+        "lodash": "^4.17.21",
         "prop-types": "^15.8.1",
         "react-collapsed": "^3.3.0",
         "recent-searches": "^1.0.5",
@@ -61,7 +62,6 @@
         "eslint-plugin-react-perf": "^3.3.1",
         "generate-license-file": "^1.3.0",
         "jest": "^27.5.1",
-        "lodash": "^4.17.21",
         "msw": "^0.36.8",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-ui-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A library of React Components for powering Yext Search integrations",
   "author": "slapshot@yext.com",
   "license": "BSD-3-Clause",
@@ -83,7 +83,6 @@
     "eslint-plugin-react-perf": "^3.3.1",
     "generate-license-file": "^1.3.0",
     "jest": "^27.5.1",
-    "lodash": "^4.17.21",
     "msw": "^0.36.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -133,6 +132,7 @@
     "restoreMocks": true
   },
   "dependencies": {
+    "lodash": "^4.17.21",
     "@microsoft/api-documenter": "^7.15.3",
     "@microsoft/api-extractor": "^7.19.4",
     "@restart/hooks": "^0.4.5",

--- a/src/utils/filterutils.tsx
+++ b/src/utils/filterutils.tsx
@@ -1,5 +1,5 @@
 import { NearFilterValue, FieldValueFilter, NumberRangeValue, Matcher, SearchActions, DisplayableFacet, SelectableStaticFilter } from '@yext/search-headless-react';
-import isEqual from 'lodash/isEqual';
+import { isEqual } from 'lodash';
 import { isNumberRangeFilter } from '../models/NumberRangeFilter';
 import { SelectableFieldValueFilter } from '../models/SelectableFieldValueFilter';
 


### PR DESCRIPTION
This hot-fix resolves #294. We had `lodash` as a devDependency, even though it's used in `src`. I also updated the import of `isEqual` in `filterutils.tsx` to follow best practices.

J=SLAP-2404
TEST=none