### PR TITLE
Bump to v1.0.2 and update `search-headless-react` version

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -802,7 +802,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless-react@2.0.0
+ - @yext/search-headless-react@2.0.1
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-ui-react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-ui-react",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@microsoft/api-documenter": "^7.15.3",
@@ -52,7 +52,7 @@
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/eslint-config-slapshot": "^0.5.0",
-        "@yext/search-headless-react": "^2.0.0",
+        "@yext/search-headless-react": "^2.0.1",
         "axe-playwright": "^1.1.11",
         "babel-jest": "^27.0.6",
         "eslint": "^8.11.0",
@@ -68,7 +68,7 @@
         "typescript": "~4.4.3"
       },
       "peerDependencies": {
-        "@yext/search-headless-react": "^2.0.0",
+        "@yext/search-headless-react": "^2.0.1",
         "react": "^16.14 || ^17 || ^18"
       }
     },
@@ -7784,9 +7784,9 @@
       }
     },
     "node_modules/@yext/search-headless-react": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.0.0.tgz",
-      "integrity": "sha512-Ad5h9tdU3ESu7+oH3pUSEXm3LgHLpXEA3q+aWAOu7b1i3FMEa3bv/R+az+eX4wQAr28mZs8R1+aKfu4S2Rm1dg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.0.1.tgz",
+      "integrity": "sha512-OJfmIC9pfSG05UQw9vfcyImvk2nhlWs4cQqn4hkJAO7GqEKT70CuLHApyM7a1o8k8dQdHkm5QHJeJmbHBus4jw==",
       "dev": true,
       "dependencies": {
         "@yext/search-headless": "^2.0.0",
@@ -33010,9 +33010,9 @@
       }
     },
     "@yext/search-headless-react": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.0.0.tgz",
-      "integrity": "sha512-Ad5h9tdU3ESu7+oH3pUSEXm3LgHLpXEA3q+aWAOu7b1i3FMEa3bv/R+az+eX4wQAr28mZs8R1+aKfu4S2Rm1dg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.0.1.tgz",
+      "integrity": "sha512-OJfmIC9pfSG05UQw9vfcyImvk2nhlWs4cQqn4hkJAO7GqEKT70CuLHApyM7a1o8k8dQdHkm5QHJeJmbHBus4jw==",
       "dev": true,
       "requires": {
         "@yext/search-headless": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-ui-react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A library of React Components for powering Yext Search integrations",
   "author": "slapshot@yext.com",
   "license": "BSD-3-Clause",
@@ -73,7 +73,7 @@
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
     "@yext/eslint-config-slapshot": "^0.5.0",
-    "@yext/search-headless-react": "^2.0.0",
+    "@yext/search-headless-react": "^2.0.1",
     "axe-playwright": "^1.1.11",
     "babel-jest": "^27.0.6",
     "eslint": "^8.11.0",
@@ -89,7 +89,7 @@
     "typescript": "~4.4.3"
   },
   "peerDependencies": {
-    "@yext/search-headless-react": "^2.0.0",
+    "@yext/search-headless-react": "^2.0.1",
     "react": "^16.14 || ^17 || ^18"
   },
   "jest": {

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -28,7 +28,7 @@
     },
     "..": {
       "name": "@yext/search-ui-react",
-      "version": "1.0.0-alpha.301",
+      "version": "1.0.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@microsoft/api-documenter": "^7.15.3",
@@ -38,6 +38,7 @@
         "@tailwindcss/forms": "^0.5.0",
         "@yext/analytics": "^0.2.0-beta.3",
         "classnames": "^2.3.1",
+        "lodash": "^4.17.21",
         "prop-types": "^15.8.1",
         "react-collapsed": "^3.3.0",
         "recent-searches": "^1.0.5",
@@ -73,17 +74,15 @@
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/eslint-config-slapshot": "^0.5.0",
-        "@yext/search-headless-react": "2.0.0-alpha.158",
+        "@yext/search-headless-react": "^2.0.1",
         "axe-playwright": "^1.1.11",
         "babel-jest": "^27.0.6",
-        "babel-loader": "^8.2.3",
         "eslint": "^8.11.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-react-hooks": "^4.3.0",
         "eslint-plugin-react-perf": "^3.3.1",
         "generate-license-file": "^1.3.0",
         "jest": "^27.5.1",
-        "lodash": "^4.17.21",
         "msw": "^0.36.8",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -91,7 +90,7 @@
         "typescript": "~4.4.3"
       },
       "peerDependencies": {
-        "@yext/search-headless-react": "2.0.0-alpha.158",
+        "@yext/search-headless-react": "^2.0.1",
         "react": "^16.14 || ^17 || ^18"
       }
     },
@@ -35326,10 +35325,9 @@
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/analytics": "^0.2.0-beta.3",
         "@yext/eslint-config-slapshot": "^0.5.0",
-        "@yext/search-headless-react": "2.0.0-alpha.158",
+        "@yext/search-headless-react": "^2.0.1",
         "axe-playwright": "^1.1.11",
         "babel-jest": "^27.0.6",
-        "babel-loader": "^8.2.3",
         "classnames": "^2.3.1",
         "eslint": "^8.11.0",
         "eslint-plugin-import": "^2.25.4",


### PR DESCRIPTION
Bump the package version to v1.0.2 and update the `search-headless-react` version to v2.0.1 to include the latest patch.