### PR TITLE
Deprecate LocationBias component

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,6 +3,7 @@ module.exports = {
     '../tests/**/*.stories.tsx'
   ],
   addons: [
+    '@etchteam/storybook-addon-status',
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',

--- a/docs/search-ui-react.locationbias.md
+++ b/docs/search-ui-react.locationbias.md
@@ -4,6 +4,11 @@
 
 ## LocationBias() function
 
+> Warning: This API is now obsolete.
+> 
+> LocationBias component has been superceded by Geolocation component.
+> 
+
 A React Component which displays and collects location information in order to bias searches.
 
 <b>Signature:</b>

--- a/docs/search-ui-react.locationbias.md
+++ b/docs/search-ui-react.locationbias.md
@@ -6,7 +6,7 @@
 
 > Warning: This API is now obsolete.
 > 
-> LocationBias component has been superceded by Geolocation component.
+> LocationBias component has been superseded by Geolocation component.
 > 
 
 A React Component which displays and collects location information in order to bias searches.

--- a/docs/search-ui-react.locationbiascssclasses.md
+++ b/docs/search-ui-react.locationbiascssclasses.md
@@ -4,6 +4,11 @@
 
 ## LocationBiasCssClasses interface
 
+> Warning: This API is now obsolete.
+> 
+> LocationBias component has been superseded by Geolocation component.
+> 
+
 The CSS class interface for the [LocationBias()](./search-ui-react.locationbias.md) component.
 
 <b>Signature:</b>

--- a/docs/search-ui-react.locationbiasprops.md
+++ b/docs/search-ui-react.locationbiasprops.md
@@ -4,6 +4,11 @@
 
 ## LocationBiasProps interface
 
+> Warning: This API is now obsolete.
+> 
+> LocationBias component has been superceded by Geolocation component.
+> 
+
 The props for the [LocationBias()](./search-ui-react.locationbias.md) component.
 
 <b>Signature:</b>

--- a/docs/search-ui-react.locationbiasprops.md
+++ b/docs/search-ui-react.locationbiasprops.md
@@ -6,7 +6,7 @@
 
 > Warning: This API is now obsolete.
 > 
-> LocationBias component has been superceded by Geolocation component.
+> LocationBias component has been superseded by Geolocation component.
 > 
 
 The props for the [LocationBias()](./search-ui-react.locationbias.md) component.

--- a/etc/search-ui-react.api.md
+++ b/etc/search-ui-react.api.md
@@ -335,10 +335,10 @@ export interface HighlightedValueCssClasses {
 // @public
 export function isCtaData(data: unknown): data is CtaData;
 
-// @public
+// @public @deprecated
 export function LocationBias({ geolocationOptions, customCssClasses }: LocationBiasProps): JSX.Element | null;
 
-// @public
+// @public @deprecated
 export interface LocationBiasCssClasses {
     // (undocumented)
     button?: string;
@@ -352,7 +352,7 @@ export interface LocationBiasCssClasses {
     source?: string;
 }
 
-// @public
+// @public @deprecated
 export interface LocationBiasProps {
     customCssClasses?: LocationBiasCssClasses;
     geolocationOptions?: PositionOptions;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@babel/preset-env": "^7.14.7",
         "@babel/preset-react": "^7.16.7",
         "@babel/preset-typescript": "^7.14.5",
+        "@etchteam/storybook-addon-status": "^4.2.2",
         "@percy/cli": "^1.8.0",
         "@percy/storybook": "^4.3.3",
         "@reduxjs/toolkit": "^1.8.6",
@@ -2280,6 +2281,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@etchteam/storybook-addon-status": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@etchteam/storybook-addon-status/-/storybook-addon-status-4.2.2.tgz",
+      "integrity": "sha512-iCOoA0+Izu/SixxjjJ9BB4YBVT2reCJ/80dXHBiCqoGSPTAvYGeeoQKexC913eSFv/0u3u4lv5fRZN/KMPAurw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "^6.2.9",
+        "@storybook/api": "^6.2.9",
+        "@storybook/client-logger": "^6.2.9",
+        "@storybook/components": "^6.2.9",
+        "@storybook/core-events": "^6.2.9",
+        "@storybook/theming": "^6.2.9",
+        "core-js": "^3.0.1",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "util-deprecate": "^1.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17.0.2 || ^18.0.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -34698,6 +34720,24 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
+      }
+    },
+    "@etchteam/storybook-addon-status": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@etchteam/storybook-addon-status/-/storybook-addon-status-4.2.2.tgz",
+      "integrity": "sha512-iCOoA0+Izu/SixxjjJ9BB4YBVT2reCJ/80dXHBiCqoGSPTAvYGeeoQKexC913eSFv/0u3u4lv5fRZN/KMPAurw==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "^6.2.9",
+        "@storybook/api": "^6.2.9",
+        "@storybook/client-logger": "^6.2.9",
+        "@storybook/components": "^6.2.9",
+        "@storybook/core-events": "^6.2.9",
+        "@storybook/theming": "^6.2.9",
+        "core-js": "^3.0.1",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "util-deprecate": "^1.0.2"
       }
     },
     "@gar/promisify": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@babel/preset-env": "^7.14.7",
     "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.14.5",
+    "@etchteam/storybook-addon-status": "^4.2.2",
     "@percy/cli": "^1.8.0",
     "@percy/storybook": "^4.3.3",
     "@reduxjs/toolkit": "^1.8.6",
@@ -134,7 +135,6 @@
     "restoreMocks": true
   },
   "dependencies": {
-    "lodash": "^4.17.21",
     "@microsoft/api-documenter": "^7.15.3",
     "@microsoft/api-extractor": "^7.19.4",
     "@reach/auto-id": "^0.18.0",
@@ -142,6 +142,7 @@
     "@tailwindcss/forms": "^0.5.0",
     "@yext/analytics": "^0.2.0-beta.3",
     "classnames": "^2.3.1",
+    "lodash": "^4.17.21",
     "mapbox-gl": "^2.9.2",
     "prop-types": "^15.8.1",
     "react-collapsed": "^3.3.0",

--- a/src/components/LocationBias.tsx
+++ b/src/components/LocationBias.tsx
@@ -33,7 +33,7 @@ const builtInCssClasses: Readonly<LocationBiasCssClasses> = {
  *
  * @public
  *
- * @deprecated LocationBias component has been superceded by Geolocation component.
+ * @deprecated LocationBias component has been superseded by Geolocation component.
  */
 export interface LocationBiasProps {
   /** Configuration used when collecting the user's location.
@@ -49,7 +49,7 @@ export interface LocationBiasProps {
  *
  * @public
  *
- * @deprecated LocationBias component has been superceded by Geolocation component.
+ * @deprecated LocationBias component has been superseded by Geolocation component.
  *
  * @param props - {@link LocationBiasProps}
  * @returns A react component for Location Bias

--- a/src/components/LocationBias.tsx
+++ b/src/components/LocationBias.tsx
@@ -9,6 +9,8 @@ import LoadingIndicator from '../icons/LoadingIndicator';
  * The CSS class interface for the {@link LocationBias} component.
  *
  * @public
+ *
+ * @deprecated LocationBias component has been superseded by Geolocation component.
  */
 export interface LocationBiasCssClasses {
   locationBiasContainer?: string,
@@ -30,6 +32,8 @@ const builtInCssClasses: Readonly<LocationBiasCssClasses> = {
  * The props for the {@link LocationBias} component.
  *
  * @public
+ *
+ * @deprecated LocationBias component has been superceded by Geolocation component.
  */
 export interface LocationBiasProps {
   /** Configuration used when collecting the user's location.
@@ -44,6 +48,8 @@ export interface LocationBiasProps {
  * A React Component which displays and collects location information in order to bias searches.
  *
  * @public
+ *
+ * @deprecated LocationBias component has been superceded by Geolocation component.
  *
  * @param props - {@link LocationBiasProps}
  * @returns A react component for Location Bias

--- a/tests/components/LocationBias.stories.tsx
+++ b/tests/components/LocationBias.stories.tsx
@@ -15,7 +15,12 @@ const meta: ComponentMeta<typeof LocationBias> = {
     geolocationOptions: {
       control: false
     }
-  }
+  },
+  parameters: {
+    status: {
+      type: 'deprecated',
+    }
+  },
 };
 export default meta;
 


### PR DESCRIPTION
this pr mark LocationBias as deprecated in favor of the new Geolocation component.

I checked if storybook have some feature to inform user that a component is deprecated, there's an open feature request: https://github.com/storybookjs/storybook/issues/9721 for displaying @deprecated props but nothing official yet. I did come across a custom addon: https://storybook.js.org/addons/@etchteam/storybook-addon-status which seems to work quite nicely.

Show "Deprecated" status for location bias stories:
<img width="782" alt="Screen Shot 2022-11-16 at 4 31 20 PM" src="https://user-images.githubusercontent.com/36055303/202298691-49bd8a5a-9332-4f93-8f42-0a7c408ae052.png">

J=SLAP-2448
TEST=none

