### PR TITLE
Update Geolocation to remove all location fields

### DIFF
--- a/src/hooks/useGeolocationHandler.ts
+++ b/src/hooks/useGeolocationHandler.ts
@@ -3,7 +3,8 @@ import { executeSearch } from '../utils/search-operations';
 import { getUserLocation } from '../utils/location-operations';
 import { useCallback, useState } from 'react';
 
-const LOCATION_FIELD_ID = 'builtin.location';
+const GEOLOCATION_FIELD_ID = 'builtin.location';
+const LOCATION_FIELD_IDS = [GEOLOCATION_FIELD_ID, 'builtin.region', 'address.countryCode'];
 const METERS_PER_MILE = 1609.344;
 
 /**
@@ -49,7 +50,7 @@ export function useGeolocationHandler({
       selected: true,
       filter: {
         kind: 'fieldValue',
-        fieldId: LOCATION_FIELD_ID,
+        fieldId: GEOLOCATION_FIELD_ID,
         matcher: Matcher.Near,
         value: {
           lat: latitude,
@@ -60,7 +61,7 @@ export function useGeolocationHandler({
     };
     const nonLocationFilters = staticFilters.filter(filter => {
       return !(filter.filter.kind === 'fieldValue'
-        && filter.filter.fieldId === LOCATION_FIELD_ID);
+        && LOCATION_FIELD_IDS.includes(filter.filter.fieldId));
     });
     searchActions.setStaticFilters([...nonLocationFilters, locationFilter]);
     executeSearch(searchActions);

--- a/tests/components/Geolocation.test.tsx
+++ b/tests/components/Geolocation.test.tsx
@@ -55,6 +55,26 @@ const mockedStateWithFilters: Partial<State> = {
         }
       },
       {
+        displayName: 'Virginia, US',
+        selected: true,
+        filter: {
+          kind: 'fieldValue',
+          fieldId: 'builtin.region',
+          matcher: Matcher.Equals,
+          value: 'US-VA',
+        }
+      },
+      {
+        displayName: 'United States',
+        selected: true,
+        filter: {
+          kind: 'fieldValue',
+          fieldId: 'address.countryCode',
+          matcher: Matcher.Equals,
+          value: 'US',
+        }
+      },
+      {
         displayName: 'My name',
         selected: true,
         filter: {
@@ -141,7 +161,7 @@ describe('custom click handler', () => {
 describe('default click handler', () => {
   it('sets a location filter using provided radius', async () => {
     const actions = spyOnActions();
-    render(<Geolocation radius={10}/>);
+    render(<Geolocation radius={10} />);
     clickUpdateLocation();
 
     const expectedLocationFilter: SelectableStaticFilter = createLocationFilter(10 * 1609.344);
@@ -162,7 +182,7 @@ describe('default click handler', () => {
     });
   });
 
-  it('replace existing location filters with a new location filter in static filters state', async () => {
+  it('replaces existing location filters with a new location filter in static filters state', async () => {
     mockAnswersState(mockedStateWithFilters);
     const actions = spyOnActions();
     render(<Geolocation />);
@@ -189,7 +209,7 @@ describe('default click handler', () => {
   it('sets a location filter using a larger radius than provided value due to low accuracy of user coordinate', async () => {
     jest.spyOn(locationOperations, 'getUserLocation').mockResolvedValue(newGeoPositionWithLowAccuracy);
     const actions = spyOnActions();
-    render(<Geolocation radius={10}/>);
+    render(<Geolocation radius={10} />);
     clickUpdateLocation();
 
     const accuracy = newGeoPositionWithLowAccuracy.coords.accuracy;


### PR DESCRIPTION
Update `useGeolocationHandler` so that it replaces all location filters with the new filter. In other words, filters on the `builtin.location`, `builtin.region`, and `address.countryCode` fields are all removed when a new filter is selected via the `Geolocation` component. This matches the behavior of `FilterSearch` and ensures the `State` doesn't end up with multiple location filters applied at the same time, which can have unpredictable results from the backend.

J=SLAP-2495
TEST=auto

See that the Jest tests still pass even when the mocked state includes other kinds of location filters besides those on `builtin.location`.