### PR TITLE
Remove Node 12 deprecation warnings

### DIFF
--- a/.github/workflows/sync-sites-branch.yml
+++ b/.github/workflows/sync-sites-branch.yml
@@ -4,20 +4,23 @@ on:
   push:
     branches:
       - main
+
 jobs:
   sync-branches:
     runs-on: ubuntu-latest
     name: Syncing branches
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: mtanzi/action-automerge@v1
+        uses: actions/checkout@v3
+      - uses: devmasx/merge-branch@v1.4.0
         with:
-          source: "${{ github.event.repository.default_branch }}"
-          target: "storybook-site"
+          type: now
+          from_branch: ${{ github.event.repository.default_branch }}
+          target_branch: storybook-site
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: mtanzi/action-automerge@v1
+      - uses: devmasx/merge-branch@v1.4.0
         with:
-          source: "${{ github.event.repository.default_branch }}"
-          target: "test-site"
+          type: now
+          from_branch: ${{ github.event.repository.default_branch }}
+          target_branch: test-site
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update the `sync-sites-branch` GH workflow to remove Node 12 deprecation [warnings](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) caused by `mtanzi/action-automerge` and an older version of `actions/checkout`. Since `mtanzi/action-automerge` has not been updated in a couple years, I replaced it with `devmasx/merge-branch`, which seems to be more actively maintained, is more widely used in the [GH Marketplace](https://github.com/marketplace/actions/merge-branch), and doesn't produce warnings.

J=SLAP-2468
TEST=manual

Test on a forked repo and see that the workflow doesn't have any warnings. The default branch of the repo is successfully synced with a test branch with a merge commit titled `Merge <default-branch> into <target-branch>`.