### PR TITLE
Pin react-collapsed to minor version

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -3522,22 +3522,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - performance-now@2.1.0
-
-This package contains the following license and notice below:
-
-Copyright (c) 2013 Braveg1rl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------------
-
-The following NPM package may be included in this product:
-
  - picocolors@1.0.0
 
 This package contains the following license and notice below:
@@ -3883,23 +3867,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - raf@3.4.1
-
-This package contains the following license and notice below:
-
-Copyright 2013 Chris Dickinson <chris@neversaw.us>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------------
-
-The following NPM package may be included in this product:
-
- - react-collapsed@3.3.0
+ - react-collapsed@3.6.0
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "lodash": "^4.17.21",
         "mapbox-gl": "^2.9.2",
         "prop-types": "^15.8.1",
-        "react-collapsed": "^3.3.0",
+        "react-collapsed": "~3.6.0",
         "recent-searches": "^1.0.5",
         "tailwind-merge": "^1.3.0",
         "use-isomorphic-layout-effect": "^1.1.2"
@@ -27015,10 +27015,6 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
@@ -27823,13 +27819,6 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "node_modules/ramda": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
@@ -27922,18 +27911,15 @@
       }
     },
     "node_modules/react-collapsed": {
-      "version": "3.3.0",
-      "integrity": "sha512-2oXo9xsleo3ZwmNP7GymWbkZp2SwDZImLduy1LKgQMsqZTDldyzP2GnfvYb9vyGFDYHRYFhnWlwDmG2yWkt8eQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/react-collapsed/-/react-collapsed-3.6.0.tgz",
+      "integrity": "sha512-QqtogOGl5hM9L7j7rlMCYxm4jD8Ovr8voqyYS1g5ltADhUNvxbbgtJ5MwRiajJ0DmYFOZHShpnSPz4wvJaOiKA==",
       "dependencies": {
-        "raf": "^3.4.1",
         "tiny-warning": "^1.0.3"
       },
-      "engines": {
-        "node": ">=12"
-      },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^16.8 || ^17",
+        "react-dom": "^16.8 || ^17"
       }
     },
     "node_modules/react-docgen": {
@@ -53697,10 +53683,6 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "picocolors": {
       "version": "1.0.0",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
@@ -54279,13 +54261,6 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
-    "raf": {
-      "version": "3.4.1",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "ramda": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
@@ -54354,10 +54329,10 @@
       }
     },
     "react-collapsed": {
-      "version": "3.3.0",
-      "integrity": "sha512-2oXo9xsleo3ZwmNP7GymWbkZp2SwDZImLduy1LKgQMsqZTDldyzP2GnfvYb9vyGFDYHRYFhnWlwDmG2yWkt8eQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/react-collapsed/-/react-collapsed-3.6.0.tgz",
+      "integrity": "sha512-QqtogOGl5hM9L7j7rlMCYxm4jD8Ovr8voqyYS1g5ltADhUNvxbbgtJ5MwRiajJ0DmYFOZHShpnSPz4wvJaOiKA==",
       "requires": {
-        "raf": "^3.4.1",
         "tiny-warning": "^1.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "lodash": "^4.17.21",
     "mapbox-gl": "^2.9.2",
     "prop-types": "^15.8.1",
-    "react-collapsed": "^3.3.0",
+    "react-collapsed": "~3.6.0",
     "recent-searches": "^1.0.5",
     "tailwind-merge": "^1.3.0",
     "use-isomorphic-layout-effect": "^1.1.2"

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -32,7 +32,7 @@
     },
     "..": {
       "name": "@yext/search-ui-react",
-      "version": "1.1.0-beta.335",
+      "version": "1.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@microsoft/api-documenter": "^7.15.3",
@@ -45,7 +45,7 @@
         "lodash": "^4.17.21",
         "mapbox-gl": "^2.9.2",
         "prop-types": "^15.8.1",
-        "react-collapsed": "^3.3.0",
+        "react-collapsed": "~3.6.0",
         "recent-searches": "^1.0.5",
         "tailwind-merge": "^1.3.0",
         "use-isomorphic-layout-effect": "^1.1.2"
@@ -55,6 +55,7 @@
         "@babel/preset-env": "^7.14.7",
         "@babel/preset-react": "^7.16.7",
         "@babel/preset-typescript": "^7.14.5",
+        "@etchteam/storybook-addon-status": "^4.2.2",
         "@percy/cli": "^1.8.0",
         "@percy/storybook": "^4.3.3",
         "@reduxjs/toolkit": "^1.8.6",
@@ -20080,6 +20081,7 @@
         "@babel/preset-env": "^7.14.7",
         "@babel/preset-react": "^7.16.7",
         "@babel/preset-typescript": "^7.14.5",
+        "@etchteam/storybook-addon-status": "^4.2.2",
         "@microsoft/api-documenter": "^7.15.3",
         "@microsoft/api-extractor": "^7.19.4",
         "@percy/cli": "^1.8.0",
@@ -20126,7 +20128,7 @@
         "msw": "^0.36.8",
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
-        "react-collapsed": "^3.3.0",
+        "react-collapsed": "~3.6.0",
         "react-dom": "^17.0.2",
         "recent-searches": "^1.0.5",
         "tailwind-merge": "^1.3.0",


### PR DESCRIPTION
This PR pins `react-collapsed` to the latest minor version (v3.6.0) that supports React 17. In v3.7.0 and v3.8.0, `react-collapsed` fixed a bug ([Slack thread](https://yext.slack.com/archives/C032CKFARGS/p1671130163844249), [GH issue](https://github.com/roginfarrer/react-collapsed/issues/103)) that occurs when using it with React 18 by introducing a breaking change where they dropped compatibility with React 16 and 17. v3.7.0+ would break a search experience using collapsible facets with React <18. Since they are not able to support both React 17 and 18 together, it seems preferable to pin to a version that can be used with both, but is a little buggy with React 18, rather than fully functional with React 18, but breaks other React experiences.

J=SLAP-2521
TEST=manual

See that collapsible facets works as expected on a test-site running on React 17 and that the site running on React 18 still has most functionality, except for the bug described above.