### PR TITLE
Update @yext/search-headless-react Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ lib/
 
 .env
 test-site/.env
+
+.idea/

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -1020,7 +1020,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-core@2.1.0
+ - @yext/search-core@2.3.0-beta.1
 
 This package contains the following license and notice below:
 
@@ -1064,7 +1064,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless-react@2.1.0
+ - @yext/search-headless-react@2.2.0-beta.0
 
 This package contains the following license and notice below:
 
@@ -1108,7 +1108,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless@2.1.0
+ - @yext/search-headless@2.2.1-beta.0
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/eslint-config-slapshot": "^0.5.0",
-        "@yext/search-headless-react": "^2.1.0",
+        "@yext/search-headless-react": "^2.2.0-beta.0",
         "axe-playwright": "^1.1.11",
         "babel-jest": "^27.0.6",
         "eslint": "^8.11.0",
@@ -71,7 +71,7 @@
         "typescript": "~4.5.5"
       },
       "peerDependencies": {
-        "@yext/search-headless-react": "^2.1.0",
+        "@yext/search-headless-react": "^2.2.0-beta.0",
         "react": "^16.14 || ^17 || ^18",
         "react-dom": "^16.14 || ^17 || ^18"
       }
@@ -10738,9 +10738,9 @@
       }
     },
     "node_modules/@yext/search-core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.1.0.tgz",
-      "integrity": "sha512-zlR3es8AYWKowp+h5uAdvNyyy66xI3FBq6YA5RRF+47J/Zrg9JDM95O+GzkQD1c9yuy4aRDn+NB59f05VQwACQ==",
+      "version": "2.3.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.3.0-beta.1.tgz",
+      "integrity": "sha512-qO8OC88ZftVLVxyylG0CxM/1Jf6xCVpztwDEKnDu/3lKw9Iq/zHZA7E487y1Ja2MraU6WuiMUNFYJpzYRLOcIw==",
       "dev": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
@@ -10751,24 +10751,24 @@
       }
     },
     "node_modules/@yext/search-headless": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.1.0.tgz",
-      "integrity": "sha512-OGjqC9NxSTUCZRdxLEHNpww3QGhypmLTRvjlDxwtVWSsAhWWWMEh1iUmo0fVsdLq7SAmxa5t11V2dgZhk9HMcQ==",
+      "version": "2.2.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.2.1-beta.0.tgz",
+      "integrity": "sha512-90uvmnE2sOTnv23hTDm4y/DkPsWollufdbNRL43c2RZCsh8GAh2IEWVd1nIdz3k1Ac26XS6kUGVCrGh2TlrWRw==",
       "dev": true,
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^2.1.0",
+        "@yext/search-core": "^2.3.0-beta.1",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@yext/search-headless-react": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.1.0.tgz",
-      "integrity": "sha512-1+alKkKRryyVSYB484Sd8d8VXym+Gd56E7s2JzECaRzWd6ql/JEjloNirzPrLhQuqIH+UhpMg4x6OCcuIp9KvA==",
+      "version": "2.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.2.0-beta.0.tgz",
+      "integrity": "sha512-fyMHbIWy+xJxZ36YSmBCCFX07fVUboxuVXNIBFn9u7L4DI97daulZE4v0SCtyHm3opgwLvCcx/OggmhLqfbhMQ==",
       "dev": true,
       "dependencies": {
-        "@yext/search-headless": "^2.1.0",
+        "@yext/search-headless": "^2.2.1-beta.0",
         "use-sync-external-store": "^1.1.0"
       },
       "peerDependencies": {
@@ -41108,9 +41108,9 @@
       }
     },
     "@yext/search-core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.1.0.tgz",
-      "integrity": "sha512-zlR3es8AYWKowp+h5uAdvNyyy66xI3FBq6YA5RRF+47J/Zrg9JDM95O+GzkQD1c9yuy4aRDn+NB59f05VQwACQ==",
+      "version": "2.3.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.3.0-beta.1.tgz",
+      "integrity": "sha512-qO8OC88ZftVLVxyylG0CxM/1Jf6xCVpztwDEKnDu/3lKw9Iq/zHZA7E487y1Ja2MraU6WuiMUNFYJpzYRLOcIw==",
       "dev": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
@@ -41118,24 +41118,24 @@
       }
     },
     "@yext/search-headless": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.1.0.tgz",
-      "integrity": "sha512-OGjqC9NxSTUCZRdxLEHNpww3QGhypmLTRvjlDxwtVWSsAhWWWMEh1iUmo0fVsdLq7SAmxa5t11V2dgZhk9HMcQ==",
+      "version": "2.2.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.2.1-beta.0.tgz",
+      "integrity": "sha512-90uvmnE2sOTnv23hTDm4y/DkPsWollufdbNRL43c2RZCsh8GAh2IEWVd1nIdz3k1Ac26XS6kUGVCrGh2TlrWRw==",
       "dev": true,
       "requires": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^2.1.0",
+        "@yext/search-core": "^2.3.0-beta.1",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }
     },
     "@yext/search-headless-react": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.1.0.tgz",
-      "integrity": "sha512-1+alKkKRryyVSYB484Sd8d8VXym+Gd56E7s2JzECaRzWd6ql/JEjloNirzPrLhQuqIH+UhpMg4x6OCcuIp9KvA==",
+      "version": "2.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.2.0-beta.0.tgz",
+      "integrity": "sha512-fyMHbIWy+xJxZ36YSmBCCFX07fVUboxuVXNIBFn9u7L4DI97daulZE4v0SCtyHm3opgwLvCcx/OggmhLqfbhMQ==",
       "dev": true,
       "requires": {
-        "@yext/search-headless": "^2.1.0",
+        "@yext/search-headless": "^2.2.1-beta.0",
         "use-sync-external-store": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-ui-react",
-  "version": "1.1.0",
+  "version": "1.2.0-beta.0",
   "description": "A library of React Components for powering Yext Search integrations",
   "author": "slapshot@yext.com",
   "license": "BSD-3-Clause",
@@ -76,7 +76,7 @@
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
     "@yext/eslint-config-slapshot": "^0.5.0",
-    "@yext/search-headless-react": "^2.1.0",
+    "@yext/search-headless-react": "^2.2.0-beta.0",
     "axe-playwright": "^1.1.11",
     "babel-jest": "^27.0.6",
     "eslint": "^8.11.0",
@@ -93,7 +93,7 @@
     "typescript": "~4.5.5"
   },
   "peerDependencies": {
-    "@yext/search-headless-react": "^2.1.0",
+    "@yext/search-headless-react": "^2.2.0-beta.0",
     "react": "^16.14 || ^17 || ^18",
     "react-dom": "^16.14 || ^17 || ^18"
   },

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -306,7 +306,7 @@ export function SearchBar({
         onClick={handleSubmit}
       >
         {renderAutocompleteResult(
-          { value: result.query },
+          { value: result.query, inputIntents: [] },
           recentSearchesCssClasses,
           RecentSearchIcon,
           `recent search: ${result.query}`
@@ -349,7 +349,10 @@ export function SearchBar({
             onClick={handleSubmit}
           >
             {renderAutocompleteResult(
-              { value: `in ${verticalKeyToLabel ? verticalKeyToLabel(verticalKey) : verticalKey}` },
+              {
+                value: `in ${verticalKeyToLabel ? verticalKeyToLabel(verticalKey) : verticalKey}`,
+                inputIntents: []
+              },
               { ...cssClasses, option: cssClasses.verticalLink }
             )}
           </DropdownItem>


### PR DESCRIPTION
This change updates @yext/search-headless-react to version 2.2.0-beta.0 which contains the EU endpoints change. It also bumps @yext/search-ui-react to version 1.2.0-beta.0.

J=BACK-2270
TEST=auto,manual

Ran `npm run test`.
Ran `npx serve .` under test-site/.