### PR TITLE
Version 1.2.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,16 +6,6 @@ name: Run Tests
 on: [push, pull_request]
 
 jobs:
-  call_run_tests-react-18:
-    uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
-    with:
-      build_script: |
-        npm i -D react@18 react-dom@18
-        npm run build
-      node_matrix: '["14.x", "16.x", "18.x"]'
-    secrets:
-      MAPBOX_API_KEY: ${{ secrets.MAPBOX_API_KEY }}
-
   call_run_tests-react-17:
     uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
     with:

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -3522,22 +3522,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - performance-now@2.1.0
-
-This package contains the following license and notice below:
-
-Copyright (c) 2013 Braveg1rl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------------
-
-The following NPM package may be included in this product:
-
  - picocolors@1.0.0
 
 This package contains the following license and notice below:
@@ -3883,23 +3867,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - raf@3.4.1
-
-This package contains the following license and notice below:
-
-Copyright 2013 Chris Dickinson <chris@neversaw.us>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------------
-
-The following NPM package may be included in this product:
-
- - react-collapsed@3.3.0
+ - react-collapsed@3.6.0
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,8 +71,8 @@
       },
       "peerDependencies": {
         "@yext/search-headless-react": "^2.2.0",
-        "react": "^16.14 || ^17 || ^18",
-        "react-dom": "^16.14 || ^17 || ^18"
+        "react": "^16.14 || ^17",
+        "react-dom": "^16.14 || ^17"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-ui-react",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-ui-react",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@microsoft/api-documenter": "^7.15.3",
@@ -19,7 +19,7 @@
         "lodash": "^4.17.21",
         "mapbox-gl": "^2.9.2",
         "prop-types": "^15.8.1",
-        "react-collapsed": "^3.3.0",
+        "react-collapsed": "3.6.0",
         "recent-searches": "^1.0.5",
         "tailwind-merge": "^1.3.0",
         "use-isomorphic-layout-effect": "^1.1.2"
@@ -26993,10 +26993,6 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
@@ -27801,13 +27797,6 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "node_modules/ramda": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
@@ -27900,18 +27889,15 @@
       }
     },
     "node_modules/react-collapsed": {
-      "version": "3.3.0",
-      "integrity": "sha512-2oXo9xsleo3ZwmNP7GymWbkZp2SwDZImLduy1LKgQMsqZTDldyzP2GnfvYb9vyGFDYHRYFhnWlwDmG2yWkt8eQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/react-collapsed/-/react-collapsed-3.6.0.tgz",
+      "integrity": "sha512-QqtogOGl5hM9L7j7rlMCYxm4jD8Ovr8voqyYS1g5ltADhUNvxbbgtJ5MwRiajJ0DmYFOZHShpnSPz4wvJaOiKA==",
       "dependencies": {
-        "raf": "^3.4.1",
         "tiny-warning": "^1.0.3"
       },
-      "engines": {
-        "node": ">=12"
-      },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^16.8 || ^17",
+        "react-dom": "^16.8 || ^17"
       }
     },
     "node_modules/react-docgen": {
@@ -53657,10 +53643,6 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "picocolors": {
       "version": "1.0.0",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
@@ -54239,13 +54221,6 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
-    "raf": {
-      "version": "3.4.1",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "ramda": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
@@ -54314,10 +54289,10 @@
       }
     },
     "react-collapsed": {
-      "version": "3.3.0",
-      "integrity": "sha512-2oXo9xsleo3ZwmNP7GymWbkZp2SwDZImLduy1LKgQMsqZTDldyzP2GnfvYb9vyGFDYHRYFhnWlwDmG2yWkt8eQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/react-collapsed/-/react-collapsed-3.6.0.tgz",
+      "integrity": "sha512-QqtogOGl5hM9L7j7rlMCYxm4jD8Ovr8voqyYS1g5ltADhUNvxbbgtJ5MwRiajJ0DmYFOZHShpnSPz4wvJaOiKA==",
       "requires": {
-        "raf": "^3.4.1",
         "tiny-warning": "^1.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-ui-react",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A library of React Components for powering Yext Search integrations",
   "author": "slapshot@yext.com",
   "license": "BSD-3-Clause",
@@ -144,7 +144,7 @@
     "classnames": "^2.3.1",
     "mapbox-gl": "^2.9.2",
     "prop-types": "^15.8.1",
-    "react-collapsed": "^3.3.0",
+    "react-collapsed": "3.6.0",
     "recent-searches": "^1.0.5",
     "tailwind-merge": "^1.3.0",
     "use-isomorphic-layout-effect": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
   },
   "peerDependencies": {
     "@yext/search-headless-react": "^2.2.0",
-    "react": "^16.14 || ^17 || ^18",
-    "react-dom": "^16.14 || ^17 || ^18"
+    "react": "^16.14 || ^17",
+    "react-dom": "^16.14 || ^17"
   },
   "jest": {
     "bail": 0,


### PR DESCRIPTION
Pin react-collapsed to v3.6 which only supports React 16 and 17 and drop our official React 18 support.

J=TECHOPS-8972
TEST=manual

Created a pages test site following the Hitchhiker module and successfully added
StandardFacets and NumericalFacets to the page. Confirmed react-collapsed v3.6 was
installed.