### PR TITLE
Fix visual coverage and WCAG tests

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -29,10 +29,6 @@ module.exports = {
   staticDirs: ['./public'],
 
   webpackFinal: async (config) => {
-    //use commonjs entry point for "@reach" packages
-    config.resolve.alias['@reach/auto-id'] = require.resolve('@reach/auto-id');
-    config.resolve.alias['@reach/utils'] = require.resolve('@reach/utils');
-
     config.resolve.alias['./SearchCore'] = require.resolve('../tests/__fixtures__/core/SearchCore.ts');
     config.resolve.alias['../utils/location-operations'] = require.resolve('../tests/__fixtures__/utils/location-operations.ts');
     return config;

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -15,7 +15,7 @@ const renderFunctions: TestRunnerConfig = {
     await checkA11y(
       page,
       {
-        exclude: ['#root .mapboxgl-canvas-container'],
+        exclude: ['#root .mapboxgl-canvas-container', '.mapboxgl-marker'],
       },
       {
         axeOptions: {

--- a/tests/components/AlternativeVerticals.stories.tsx
+++ b/tests/components/AlternativeVerticals.stories.tsx
@@ -1,7 +1,7 @@
 import { ComponentMeta, Story } from '@storybook/react';
 import { SearchHeadlessContext } from '@yext/search-headless-react';
 
-import { AlternativeVerticals, AlternativeVerticalsProps } from '../../dist/index.js';
+import { AlternativeVerticals, AlternativeVerticalsProps } from '../../src/components/AlternativeVerticals';
 
 import { generateMockedHeadless } from '../__fixtures__/search-headless';
 import { VerticalSearcherState } from '../__fixtures__/headless-state';

--- a/tests/components/FilterSearch.stories.tsx
+++ b/tests/components/FilterSearch.stories.tsx
@@ -37,10 +37,10 @@ const meta: ComponentMeta<typeof FilterSearch> = {
     },
     searchFields: {
       control: false
-    },
-    label: {
-      defaultValue: 'Filter'
     }
+  },
+  args: {
+    label: "Filter"
   }
 };
 export default meta;

--- a/tests/components/MapboxMap.stories.tsx
+++ b/tests/components/MapboxMap.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentMeta, Story } from '@storybook/react';
-import { userEvent, within } from '@storybook/testing-library';
+import { within } from '@storybook/testing-library';
+import { fireEvent } from '@testing-library/react';
 import { SearchHeadlessContext } from '@yext/search-headless-react';
 
 import { generateMockedHeadless } from '../__fixtures__/search-headless';
@@ -14,12 +15,14 @@ const meta: ComponentMeta<typeof MapboxMap> = {
   component: MapboxMap,
   argTypes: {
     mapboxAccessToken: {
-      defaultValue: process.env.REACT_APP_MAPBOX_API_KEY,
       control: false,
     },
     PinComponent: {
       control: false,
     },
+  },
+  args: {
+    mapboxAccessToken: process.env.REACT_APP_MAPBOX_API_KEY,
   },
   parameters: { layout: 'fullscreen', percy: { enableJavascript: true } },
   decorators: [(Story) => (<div style={{ height: '100vh' }}><Story /></div>)]
@@ -53,6 +56,6 @@ CustomPin.play = async ({ canvasElement }) => {
   const mapPin = await canvas.findByLabelText('Show pin details', undefined, {
     timeout: 30000
   });
-  userEvent.click(mapPin);
+  fireEvent.click(mapPin);
   await canvas.findByText('title1');
 };


### PR DESCRIPTION
Make updates to the Storybook setup and stories to fix the visual coverage and WCAG checks that have been failing since the Storybook version was upgraded.

J=BACK-2831
TEST=auto