### PR TITLE
update search-headless-react dependencies version to 2.5.0-beta.3

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -1138,7 +1138,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-core@2.6.0-beta
+ - @yext/search-core@2.6.0-beta.2
 
 This package contains the following license and notice below:
 
@@ -1182,7 +1182,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless-react@2.5.0-beta.2
+ - @yext/search-headless-react@2.5.0-beta.3
 
 This package contains the following license and notice below:
 
@@ -1226,7 +1226,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless@2.6.0-beta.2
+ - @yext/search-headless@2.6.0-beta.3
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-ui-react",
-  "version": "1.7.0-beta.2",
+  "version": "1.7.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-ui-react",
-      "version": "1.7.0-beta.2",
+      "version": "1.7.0-beta.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@restart/ui": "^1.0.1",
@@ -54,7 +54,7 @@
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@yext/eslint-config-slapshot": "^0.5.0",
-        "@yext/search-headless-react": "^2.5.0-beta.2",
+        "@yext/search-headless-react": "^2.5.0-beta.3",
         "axe-core": "^4.8.2",
         "axe-playwright": "^1.2.3",
         "babel-jest": "^29.7.0",
@@ -77,7 +77,7 @@
         "util": "^0.12.5"
       },
       "peerDependencies": {
-        "@yext/search-headless-react": "^2.5.0-beta.2",
+        "@yext/search-headless-react": "^2.5.0-beta.3",
         "react": "^16.14 || ^17 || ^18",
         "react-dom": "^16.14 || ^17 || ^18"
       }
@@ -11208,9 +11208,9 @@
       }
     },
     "node_modules/@yext/search-core": {
-      "version": "2.6.0-beta",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.6.0-beta.tgz",
-      "integrity": "sha512-VUGk2cjTtnVol6+qKg/rApefNwSso8Nmuw2NvXSjh3UEarJMwEwWwkGLkTfFnQo+NksNNQq175ysfEx6cgC1Pw==",
+      "version": "2.6.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.6.0-beta.2.tgz",
+      "integrity": "sha512-xXd/9mWqcLV9dIeIUpzAo/JRkyvDuov3MLbqV0ymTEwRpP/HBQeATFnRsJ/C22Ep4vtjkaKhJdo0LriKDIHb5g==",
       "dev": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
@@ -11221,24 +11221,24 @@
       }
     },
     "node_modules/@yext/search-headless": {
-      "version": "2.6.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.2.tgz",
-      "integrity": "sha512-lz/LCU3yRMrlTdpQxmjw0qxNrVjCkELbnF9ZOpbGPaKOrsNyzgu00uV16ligYS65CAmLZQX/hsfWs8rVLOen2w==",
+      "version": "2.6.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.3.tgz",
+      "integrity": "sha512-snSEO15Pf92sKuCxVeUjlGy2Tj06S5KkOS3YmToXijG1PhEML121d+4qcsQB+/c4D1I5/o4Mg/RxzLa1ejWKIA==",
       "dev": true,
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^2.6.0-beta",
+        "@yext/search-core": "^2.6.0-beta.2",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@yext/search-headless-react": {
-      "version": "2.5.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.5.0-beta.2.tgz",
-      "integrity": "sha512-2UN3EIDtT1cFXxaKQ3VxCFs9DhseB6GnRgCZF+H13PuiPOpgcnYlreaTElVF5y1OgsARPTQRpxLzVCgE+137cA==",
+      "version": "2.5.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.5.0-beta.3.tgz",
+      "integrity": "sha512-vttJwhMpuP6k2rxHZiHO51rRgWmRXJLP3mufhdaHYyUiqbF15Wg7lhZdUCoJkE4R2kkCjtylfjXdWJl8o/w0DQ==",
       "dev": true,
       "dependencies": {
-        "@yext/search-headless": "^2.6.0-beta.2",
+        "@yext/search-headless": "^2.6.0-beta.3",
         "use-sync-external-store": "^1.1.0"
       },
       "peerDependencies": {
@@ -35847,9 +35847,9 @@
       }
     },
     "@yext/search-core": {
-      "version": "2.6.0-beta",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.6.0-beta.tgz",
-      "integrity": "sha512-VUGk2cjTtnVol6+qKg/rApefNwSso8Nmuw2NvXSjh3UEarJMwEwWwkGLkTfFnQo+NksNNQq175ysfEx6cgC1Pw==",
+      "version": "2.6.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.6.0-beta.2.tgz",
+      "integrity": "sha512-xXd/9mWqcLV9dIeIUpzAo/JRkyvDuov3MLbqV0ymTEwRpP/HBQeATFnRsJ/C22Ep4vtjkaKhJdo0LriKDIHb5g==",
       "dev": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
@@ -35857,24 +35857,24 @@
       }
     },
     "@yext/search-headless": {
-      "version": "2.6.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.2.tgz",
-      "integrity": "sha512-lz/LCU3yRMrlTdpQxmjw0qxNrVjCkELbnF9ZOpbGPaKOrsNyzgu00uV16ligYS65CAmLZQX/hsfWs8rVLOen2w==",
+      "version": "2.6.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.3.tgz",
+      "integrity": "sha512-snSEO15Pf92sKuCxVeUjlGy2Tj06S5KkOS3YmToXijG1PhEML121d+4qcsQB+/c4D1I5/o4Mg/RxzLa1ejWKIA==",
       "dev": true,
       "requires": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^2.6.0-beta",
+        "@yext/search-core": "^2.6.0-beta.2",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }
     },
     "@yext/search-headless-react": {
-      "version": "2.5.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.5.0-beta.2.tgz",
-      "integrity": "sha512-2UN3EIDtT1cFXxaKQ3VxCFs9DhseB6GnRgCZF+H13PuiPOpgcnYlreaTElVF5y1OgsARPTQRpxLzVCgE+137cA==",
+      "version": "2.5.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless-react/-/search-headless-react-2.5.0-beta.3.tgz",
+      "integrity": "sha512-vttJwhMpuP6k2rxHZiHO51rRgWmRXJLP3mufhdaHYyUiqbF15Wg7lhZdUCoJkE4R2kkCjtylfjXdWJl8o/w0DQ==",
       "dev": true,
       "requires": {
-        "@yext/search-headless": "^2.6.0-beta.2",
+        "@yext/search-headless": "^2.6.0-beta.3",
         "use-sync-external-store": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-ui-react",
-  "version": "1.7.0-beta.2",
+  "version": "1.7.0-beta.3",
   "description": "A library of React Components for powering Yext Search integrations",
   "author": "slapshot@yext.com",
   "license": "BSD-3-Clause",
@@ -85,7 +85,7 @@
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
     "@yext/eslint-config-slapshot": "^0.5.0",
-    "@yext/search-headless-react": "^2.5.0-beta.2",
+    "@yext/search-headless-react": "^2.5.0-beta.3",
     "axe-core": "^4.8.2",
     "axe-playwright": "^1.2.3",
     "babel-jest": "^29.7.0",
@@ -108,7 +108,7 @@
     "util": "^0.12.5"
   },
   "peerDependencies": {
-    "@yext/search-headless-react": "^2.5.0-beta.2",
+    "@yext/search-headless-react": "^2.5.0-beta.3",
     "react": "^16.14 || ^17 || ^18",
     "react-dom": "^16.14 || ^17 || ^18"
   },


### PR DESCRIPTION
New version has `queryDurationMillis` as an optional field of VerticalResults

J=CLIP-1226
TEST=auto,manual

ran `npm run test`.
temporarily added GDA to ProductsPage in test site and verified that the appropriate gda content shows up after a vertical search.
![image](https://github.com/yext/search-ui-react/assets/143001514/a6a1815e-bb95-4c1b-a9f3-e8d4a8aabcaf)