### PR TITLE
Debounce generative direct answer calls

### DIFF
--- a/src/components/GenerativeDirectAnswer.tsx
+++ b/src/components/GenerativeDirectAnswer.tsx
@@ -11,7 +11,7 @@ import { useCardAnalytics } from '../hooks/useCardAnalytics';
 import { DefaultRawDataType } from '../models/index';
 import { executeGenerativeDirectAnswer } from '../utils/search-operations';
 import { Markdown, MarkdownCssClasses } from './Markdown';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 
 /**
  * The CSS class interface used for {@link GenerativeDirectAnswer}.
@@ -92,17 +92,19 @@ export function GenerativeDirectAnswer({
     }
   }, [isUniversal, universalResults, verticalResults]);
 
+  const [lastExecutedSearchResults, setLastExecutedSearchResults] = useState(searchResults);
   const searchActions = useSearchActions();
   const gdaResponse = useSearchState(state => state.generativeDirectAnswer?.response);
   const isLoading = useSearchState(state => state.generativeDirectAnswer?.isLoading);
   const handleClickEvent = useReportClickEvent();
 
   React.useEffect(() => {
-    if (!searchResults?.length || !searchId) {
+    if (!searchResults?.length || !searchId || searchResults === lastExecutedSearchResults) {
       return;
     }
     executeGenerativeDirectAnswer(searchActions);
-  }, [searchResults, searchId]);
+    setLastExecutedSearchResults(searchResults);
+  }, [searchResults, searchId, lastExecutedSearchResults]);
 
   if (!searchResults?.length || isLoading || !gdaResponse || gdaResponse.resultStatus !== 'SUCCESS') {
     return null;
@@ -152,7 +154,7 @@ function Answer(props: AnswerProps) {
     }),
     [cssClasses.answerText]
   );
-  
+
   return <>
     <div className={cssClasses.header}>
       {answerHeader ?? t('aiGeneratedAnswer')}


### PR DESCRIPTION
The effect hook that triggers a GDA call has two dependencies: the search results and the search ID. These both change when a search is made. In React 18, these updates are batched together so only one call to GDA gets made when the search is updated. However, in React 17, no batching is performed and updates are handled in order, meaning a call to GDA is made when the search results are updated and when the search ID is updated, even if the same search triggers both updates. This change tracks the search results and only executes a new GDA call if the search results have changed.

J=WAT-4861
TEST=manual

Created a local test site that runs on React 17. Made a local tarball with my changes to search-ui-react using npm pack and pointed the local test site's import of search-ui-react to the tarball. Confirmed that only one GDA call is made per-seasrch.

Also spun up the search-ui-react test-site (which runs on React 18) and confirmed that GDA calls are still made once per search as expected.