### PR TITLE
fix: update map bounds check to use client values

### DIFF
--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -340,6 +340,9 @@ export function MapboxMap<T>({
           const markerLocation = getCoordinate(result);
           if (markerLocation) {
             const { latitude, longitude } = markerLocation;
+            if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+              return;
+            }
             const el = document.createElement('div');
             let markerOptions: mapboxgl.MarkerOptions = {};
             if (PinComponent) {
@@ -382,8 +385,14 @@ export function MapboxMap<T>({
           }
         });
 
+        mapbox.resize();
         const canvas = mapbox.getCanvas();
-        if (!bounds.isEmpty() && !!canvas && canvas.height > 0 && canvas.width > 0) {
+
+        if (!bounds.isEmpty()
+            && !!canvas
+            && canvas.clientHeight > 0
+            && canvas.clientWidth > 0
+        ) {
           const resolvedOptions = {
             // these settings are defaults and will be overriden if present on fitBoundsOptions
             padding: { top: 50, bottom: 50, left: 50, right: 50 },
@@ -410,14 +419,14 @@ export function MapboxMap<T>({
 
           // Padding must not exceed the map's canvas dimensions
           const verticalPaddingSum = resolvedPadding.top + resolvedPadding.bottom;
-          if (verticalPaddingSum >= canvas.height) {
-            const ratio = canvas.height / (verticalPaddingSum || 1);
+          if (verticalPaddingSum >= canvas.clientHeight) {
+            const ratio = canvas.clientHeight / (verticalPaddingSum || 1);
             resolvedPadding.top = Math.max(0, resolvedPadding.top * ratio - 1);
             resolvedPadding.bottom = Math.max(0, resolvedPadding.bottom * ratio - 1);
           }
           const horizontalPaddingSum = resolvedPadding.left + resolvedPadding.right;
-          if (horizontalPaddingSum >= canvas.width) {
-            const ratio = canvas.width / (horizontalPaddingSum || 1);
+          if (horizontalPaddingSum >= canvas.clientWidth) {
+            const ratio = canvas.clientWidth / (horizontalPaddingSum || 1);
             resolvedPadding.left = Math.max(0, resolvedPadding.left * ratio - 1);
             resolvedPadding.right = Math.max(0, resolvedPadding.right * ratio - 1);
           }

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -34,7 +34,7 @@
     },
     "..": {
       "name": "@yext/search-ui-react",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@restart/ui": "^1.0.1",


### PR DESCRIPTION
This was apparently causing more `Invalid LngLat` issues in iframes. Now, the map should be correctly sized and taking into account it's actual viewport size.

The map's actual viewport is the canvas **client size**. `canvas.width/height` represents the device pixels, which is often larger than the CSS size. `canvas.clientWidth/clientHeight` uses the CSS pixel size, which is also what `fitBounds` uses, which is likely why we were running into issues before.

J=[WAT-5303](https://yext.atlassian.net/browse/WAT-5303?atlOrigin=eyJpIjoiMGQ2MzIwOGQyYTBhNDNhY2FhZjIwNTlmNGFhMjNhYWUiLCJwIjoiaiJ9)
TEST=manual
Packed tarball and saw a test VE site no longer run into the error