### PR TITLE
fix: suppress i18next console support notice

### DIFF
--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -22,7 +22,8 @@ i18nInstance.use(initReactI18next).init({
   ns: [NAMESPACE],
   defaultNS: NAMESPACE,
   interpolation: { escapeValue: false },
-  resources
+  resources,
+  showSupportNotice: false
 });
 
 export { i18nInstance };


### PR DESCRIPTION
Add showSupportNotice: false to i18next init config to prevent the Locize support notice from appearing in the console for all consumers of this library.

Closes #639