### PR TITLE
chore: upgrade transitive handlebars dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13176,9 +13176,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -194,7 +194,8 @@
   "overrides": {
     "@babel/plugin-transform-runtime": "^7.23.2",
     "rollup": "4.22.4",
-    "playwright": "1.57.0"
+    "playwright": "1.57.0",
+    "handlebars": "^4.7.9"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
4.7.8 was marked in a vuln, so bumping to 4.7.9.

J=[VULN-43322](https://yext.atlassian.net/browse/VULN-43322?atlOrigin=eyJpIjoiODhiYWE0ZjI3Nzk2NGNkZWE2YjNkN2RiYjYyN2FlMTUiLCJwIjoiaiJ9)